### PR TITLE
add purchaseMessage field

### DIFF
--- a/src/fare-product-type.ts
+++ b/src/fare-product-type.ts
@@ -56,7 +56,7 @@ export const FareProductTypeConfig = z.object({
   transportModes: z.array(ProductTypeTransportModes),
   excludedTariffZones: z.array(z.string()).optional(),
   description: LanguageAndTextTypeArray,
-  purchaseMessage: LanguageAndTextTypeArray,
+  purchaseMessage: LanguageAndTextTypeArray.optional(),
   configuration: FareProductTypeConfigSettings,
 });
 


### PR DESCRIPTION
Adds optional PurchaseMessage field to FareProductTypeConfig. Includes information presented to the user in advance of ticket purchases in the app. 

Background with more description: https://github.com/AtB-AS/mittatb-app/pull/3540#issue-1704048495