### PR TITLE
fix: Update fare product type configs to match what's actually in firestore

### DIFF
--- a/schema-definitions/fareProductTypeConfigs.json
+++ b/schema-definitions/fareProductTypeConfigs.json
@@ -279,9 +279,6 @@
         },
         "configuration": {
           "$ref": "#/definitions/FareProductTypeConfigSettings"
-        },
-        "purchaseMessage": {
-          "$ref": "#/definitions/FareProductTypeConfigSettings/properties/productSelectionTitle"
         }
       },
       "required": [

--- a/src/fare-product-type.ts
+++ b/src/fare-product-type.ts
@@ -66,7 +66,6 @@ export const FareProductTypeConfig = z.object({
   excludedTariffZones: z.array(z.string()).optional(),
   description: LanguageAndTextTypeArray,
   configuration: FareProductTypeConfigSettings,
-  purchaseMessage: LanguageAndTextTypeArray.optional(),
 });
 
 export type ProductTypeTransportModes = z.infer<


### PR DESCRIPTION
The schema in firestore-configuration ([schema-definitions/fareProductTypeConfigs.json](https://github.com/AtB-AS/firestore-configuration/blob/main/schema-definitions/fareProductTypeConfigs.json)) does not match the one generated from the typings in this repository. 

This pr adds a couple of properties that actually exist in firebase. This ensures that the generated schema can be used in `firestore-configuration`