### PR TITLE
feat: Heading for mobility operator benefit

### DIFF
--- a/schema-definitions/mobility.json
+++ b/schema-definitions/mobility.json
@@ -48,7 +48,7 @@
                         "free-use"
                       ]
                     },
-                    "descriptionWhenActive": {
+                    "headingWhenActive": {
                       "type": "array",
                       "items": {
                         "anyOf": [
@@ -83,8 +83,14 @@
                         ]
                       }
                     },
+                    "descriptionWhenActive": {
+                      "$ref": "#/definitions/MobilityOperator/properties/operators/items/properties/benefits/items/properties/headingWhenActive"
+                    },
+                    "headingWhenNotActive": {
+                      "$ref": "#/definitions/MobilityOperator/properties/operators/items/properties/benefits/items/properties/headingWhenActive"
+                    },
                     "descriptionWhenNotActive": {
-                      "$ref": "#/definitions/MobilityOperator/properties/operators/items/properties/benefits/items/properties/descriptionWhenActive"
+                      "$ref": "#/definitions/MobilityOperator/properties/operators/items/properties/benefits/items/properties/headingWhenActive"
                     },
                     "callToAction": {
                       "type": "object",
@@ -93,7 +99,7 @@
                           "type": "string"
                         },
                         "name": {
-                          "$ref": "#/definitions/MobilityOperator/properties/operators/items/properties/benefits/items/properties/descriptionWhenActive"
+                          "$ref": "#/definitions/MobilityOperator/properties/operators/items/properties/benefits/items/properties/headingWhenActive"
                         }
                       },
                       "required": [

--- a/src/mobility-operators.ts
+++ b/src/mobility-operators.ts
@@ -15,7 +15,9 @@ export type OperatorBenefitIdType = z.infer<typeof OperatorBenefitId>;
 
 export const OperatorBenefit = z.object({
   id: OperatorBenefitId,
+  headingWhenActive: LanguageAndTextTypeArray.optional(),
   descriptionWhenActive: LanguageAndTextTypeArray.optional(),
+  headingWhenNotActive: LanguageAndTextTypeArray.optional(),
   descriptionWhenNotActive: LanguageAndTextTypeArray.optional(),
   callToAction: z.object({
     url: z.string(),

--- a/src/tests/MobilityOperator.test.ts
+++ b/src/tests/MobilityOperator.test.ts
@@ -30,6 +30,10 @@ test('Mobility operator benefits', () => {
 
   assertType<OperatorBenefitType>({
     id: "free-unlock",
+    headingWhenActive: [
+      { lang: 'nob', value: 'Overkrift når aktiv'},
+      { lang: 'en', value: 'Heading when active'}
+    ],
     descriptionWhenActive: [
       { lang: 'nob', value: 'Beskrivelse når aktiv'},
       { lang: 'en', value: 'Description when active'}
@@ -37,6 +41,10 @@ test('Mobility operator benefits', () => {
     descriptionWhenNotActive: [
       { lang: 'nob', value: 'Beskrivelse når ikke aktiv'},
       { lang: 'en', value: 'Description when not active'}
+    ],
+    headingWhenNotActive: [
+      { lang: 'nob', value: 'Overskrift når ikke aktiv'},
+      { lang: 'en', value: 'Heading when not active'}
     ],
     callToAction: {
       url: "https://click.me",


### PR DESCRIPTION
Heading is required to produce improved mobility operator benefits as shown in the screenshot below.

Due to backward compatibility, the heading is added as a separate field rather than changing the structure to something like this: 
```
description: z.object({
    heading: LanguageAndTextTypeArray.optional(),
    text: LanguageAndTextTypeArray.optional(),
}),
```
![image](https://github.com/AtB-AS/fare-product-type-configs/assets/4981580/c206b5a4-e636-45b4-95e6-a9281d00fdb0)
