### PR TITLE
feat: Mobility benefit operator image

### DIFF
--- a/schema-definitions/mobility.json
+++ b/schema-definitions/mobility.json
@@ -48,7 +48,7 @@
                         "free-use"
                       ]
                     },
-                    "image": {
+                    "imageWhenActive": {
                       "type": "string"
                     },
                     "headingWhenActive": {
@@ -88,6 +88,9 @@
                     },
                     "descriptionWhenActive": {
                       "$ref": "#/definitions/MobilityOperator/properties/operators/items/properties/benefits/items/properties/headingWhenActive"
+                    },
+                    "imageWhenNotActive": {
+                      "type": "string"
                     },
                     "headingWhenNotActive": {
                       "$ref": "#/definitions/MobilityOperator/properties/operators/items/properties/benefits/items/properties/headingWhenActive"

--- a/src/mobility-operators.ts
+++ b/src/mobility-operators.ts
@@ -15,9 +15,10 @@ export type OperatorBenefitIdType = z.infer<typeof OperatorBenefitId>;
 
 export const OperatorBenefit = z.object({
   id: OperatorBenefitId,
-  image: z.string().optional(),
+  imageWhenActive: z.string().optional(),
   headingWhenActive: LanguageAndTextTypeArray.optional(),
   descriptionWhenActive: LanguageAndTextTypeArray,
+  imageWhenNotActive: z.string().optional(),
   headingWhenNotActive: LanguageAndTextTypeArray.optional(),
   descriptionWhenNotActive: LanguageAndTextTypeArray,
   callToAction: z.object({


### PR DESCRIPTION
Optional image for a mobility operator benefit. Added as a string as the intention is to have base64 encoded images in the database.

Part of https://github.com/AtB-AS/kundevendt/issues/3975