### PR TITLE
feat: Add formFactor to benefit

### DIFF
--- a/schema-definitions/mobility.json
+++ b/schema-definitions/mobility.json
@@ -116,13 +116,21 @@
                     },
                     "ticketDescription": {
                       "$ref": "#/definitions/MobilityOperator/properties/operators/items/properties/benefits/items/properties/headingWhenActive"
+                    },
+                    "formFactors": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/FormFactor"
+                      },
+                      "minItems": 1
                     }
                   },
                   "required": [
                     "id",
                     "descriptionWhenActive",
                     "descriptionWhenNotActive",
-                    "callToAction"
+                    "callToAction",
+                    "formFactors"
                   ],
                   "additionalProperties": false
                 },

--- a/src/mobility-operators.ts
+++ b/src/mobility-operators.ts
@@ -27,6 +27,7 @@ export const OperatorBenefit = z.object({
     name: LanguageAndTextTypeArray.optional(),
   }),
   ticketDescription: LanguageAndTextTypeArray.optional(),
+  formFactors: z.array(FormFactor).nonempty(),
 })
 
 export type OperatorBenefitType = z.infer<typeof OperatorBenefit>;

--- a/src/tests/MobilityOperator.test.ts
+++ b/src/tests/MobilityOperator.test.ts
@@ -52,6 +52,7 @@ test('Mobility operator benefits', () => {
         { lang: 'nob', value: 'Aktiver'},
         { lang: 'en', value: 'Do it!'}
       ]
-    }
+    },
+    formFactors: ["SCOOTER", "CAR"]
   })
 })


### PR DESCRIPTION
We need form factor on the benefit as well, as it won't always be
the same form factors as the operator has. For example the operator
may support both el-scooter and rental car, but might have a
benefit only for el-scooters.
