### PR TITLE
feat: add property to signal whether transport mode filter should be unchecked by default

### DIFF
--- a/schema-definitions/travelSearchFilters.json
+++ b/schema-definitions/travelSearchFilters.json
@@ -236,6 +236,9 @@
                 "items": {
                   "$ref": "#/definitions/TravelSearchTransportModes"
                 }
+              },
+              "isUncheckedByDefault": {
+                "type": "boolean"
               }
             },
             "required": [

--- a/src/travel-search-filters.ts
+++ b/src/travel-search-filters.ts
@@ -22,6 +22,7 @@ export const TransportModeFilterOption = z.object({
   text: LanguageAndTextTypeArray.nonempty(),
   description: LanguageAndTextTypeArray.optional(),
   modes: z.array(TravelSearchTransportModes),
+  isUncheckedByDefault: z.boolean().optional(),
 });
 
 export const FlexibleTransportOption = z.object({
@@ -37,20 +38,20 @@ export const TravelSearchPreferenceParameter = z.union([
   z.literal('waitReluctance'),
   z.literal('walkReluctance'),
   z.literal('walkSpeed'),
-])
+]);
 export const TravelSearchPreferenceOptionId = z.string().nonempty();
 export const TravelSearchPreferenceOption = z.object({
   id: TravelSearchPreferenceOptionId,
   text: LanguageAndTextTypeArray.nonempty(),
   value: z.number().nonnegative(),
-})
+});
 
 export const TravelSearchPreference = z.object({
   type: TravelSearchPreferenceParameter,
   title: LanguageAndTextTypeArray.nonempty(),
   options: TravelSearchPreferenceOption.array().nonempty(),
   defaultOption: TravelSearchPreferenceOptionId,
-})
+});
 
 export const TravelSearchFilters = z.object({
   transportModes: TransportModeFilterOption.array().optional(),
@@ -73,7 +74,13 @@ export type TransportModeFilterOptionType = z.infer<
   typeof TransportModeFilterOption
 >;
 
-export type TravelSearchPreferenceParameterType = z.infer<typeof TravelSearchPreferenceParameter>;
-export type TravelSearchPreferenceOptionIdType = z.infer<typeof TravelSearchPreferenceOptionId>;
-export type TravelSearchPreferenceOptionType = z.infer<typeof TravelSearchPreferenceOption>;
-export type TravelSearchPreferenceType = z.infer<typeof TravelSearchPreference>
+export type TravelSearchPreferenceParameterType = z.infer<
+  typeof TravelSearchPreferenceParameter
+>;
+export type TravelSearchPreferenceOptionIdType = z.infer<
+  typeof TravelSearchPreferenceOptionId
+>;
+export type TravelSearchPreferenceOptionType = z.infer<
+  typeof TravelSearchPreferenceOption
+>;
+export type TravelSearchPreferenceType = z.infer<typeof TravelSearchPreference>;


### PR DESCRIPTION
Closeshttps://github.com/AtB-AS/kundevendt/issues/16683

### Background
NFK have requested that flights are not part of the default transport methods in travel planner web. It should still be possible to enable for the users, but not selected as default.

This is default also in app and at Entur.

- [ ] Uncheck flight as default way of transport in Nordland
- [ ] Uncheck flight FRAM
- [ ] Uncheck train FRAM

### Proposed solution

- Add a property to signal whether transport mode filters should should initially not be checked.