### PR TITLE
chore: rename property to make it more descriptive.

### DIFF
--- a/examples/travelSearchFilters.yaml
+++ b/examples/travelSearchFilters.yaml
@@ -29,7 +29,7 @@ transportModes:
           - sightseeingBus
           - specialNeedsBus
       - transportMode: coach
-    defaultValue: false
+    selectedAsDefault: false
   - id: 'tram'
     icon:
       transportMode: tram
@@ -40,7 +40,7 @@ transportModes:
         value: Tram
     modes:
       - transportMode: tram
-    defaultValue: false
+    selectedAsDefault: false
   - id: 'rail'
     icon:
       transportMode: rail
@@ -54,7 +54,7 @@ transportModes:
       - transportMode: bus
         transportSubModes:
           - railReplacementBus
-    defaultValue: false
+    selectedAsDefault: false
   - id: 'speedboat'
     icon:
       transportMode: water
@@ -72,7 +72,7 @@ transportModes:
           - sightseeingService
           - localPassengerFerry
           - internationalPassengerFerry
-    defaultValue: false
+    selectedAsDefault: false
   - id: 'ferry'
     icon:
       transportMode: water
@@ -88,7 +88,7 @@ transportModes:
           - internationalCarFerry
           - localCarFerry
           - nationalCarFerry
-    defaultValue: false
+    selectedAsDefault: false
   - id: 'flybus'
     icon:
       transportMode: bus
@@ -101,7 +101,7 @@ transportModes:
       - transportMode: bus
         transportSubModes:
           - airportLinkBus
-    defaultValue: false
+    selectedAsDefault: false
   - id: 'other'
     icon:
       transportMode: unknown
@@ -123,7 +123,7 @@ transportModes:
       - transportMode: monorail
       - transportMode: lift
       - transportMode: trolleybus
-    defaultValue: false
+    selectedAsDefault: false
 flexibleTransport:
   label: 'new'
   title:

--- a/schema-definitions/travelSearchFilters.json
+++ b/schema-definitions/travelSearchFilters.json
@@ -230,11 +230,11 @@
                   "$ref": "#/definitions/TravelSearchTransportModes"
                 }
               },
-              "defaultValue": {
+              "selectedAsDefault": {
                 "type": "boolean"
               }
             },
-            "required": ["id", "icon", "text", "modes"],
+            "required": ["id", "icon", "text", "modes", "selectedAsDefault"],
             "additionalProperties": false
           }
         },

--- a/src/tests/TravelSearchTransport.test.ts
+++ b/src/tests/TravelSearchTransport.test.ts
@@ -18,7 +18,7 @@ test('TransportModeFilterOptionType', function () {
         },
       ],
       modes: [],
-      defaultValue: true,
+      selectedAsDefault: true,
     }),
   );
 });

--- a/src/tests/contract-fixtures-tests/travelSearchFilters.yaml
+++ b/src/tests/contract-fixtures-tests/travelSearchFilters.yaml
@@ -28,7 +28,7 @@ transportModes:
           - sightseeingBus
           - specialNeedsBus
       - transportMode: coach
-    defaultValue: false
+    selectedAsDefault: false
   - id: 'tram'
     icon:
       transportMode: tram
@@ -39,7 +39,7 @@ transportModes:
         value: Tram
     modes:
       - transportMode: tram
-    defaultValue: false
+    selectedAsDefault: false
   - id: 'rail'
     icon:
       transportMode: rail
@@ -53,7 +53,7 @@ transportModes:
       - transportMode: bus
         transportSubModes:
           - railReplacementBus
-    defaultValue: false
+    selectedAsDefault: false
   - id: 'speedboat'
     icon:
       transportMode: water
@@ -71,7 +71,7 @@ transportModes:
           - sightseeingService
           - localPassengerFerry
           - internationalPassengerFerry
-    defaultValue: false
+    selectedAsDefault: false
   - id: 'ferry'
     icon:
       transportMode: water
@@ -87,7 +87,7 @@ transportModes:
           - internationalCarFerry
           - localCarFerry
           - nationalCarFerry
-    defaultValue: false
+    selectedAsDefault: false
   - id: 'flybus'
     icon:
       transportMode: bus
@@ -100,7 +100,7 @@ transportModes:
       - transportMode: bus
         transportSubModes:
           - airportLinkBus
-    defaultValue: false
+    selectedAsDefault: false
   - id: 'other'
     icon:
       transportMode: unknown
@@ -122,7 +122,7 @@ transportModes:
       - transportMode: monorail
       - transportMode: lift
       - transportMode: trolleybus
-    defaultValue: false
+    selectedAsDefault: false
 flexibleTransport:
   id: 'flexibleTransport'
   label: 'new'

--- a/src/travel-search-filters.ts
+++ b/src/travel-search-filters.ts
@@ -22,7 +22,7 @@ export const TransportModeFilterOption = z.object({
   text: LanguageAndTextTypeArray.nonempty(),
   description: LanguageAndTextTypeArray.optional(),
   modes: z.array(TravelSearchTransportModes),
-  defaultValue: z.boolean(),
+  selectedAsDefault: z.boolean(),
 });
 
 export const FlexibleTransportOption = z.object({


### PR DESCRIPTION
Rename from defaultValue to selectedAsDefault to achieve a more descriptive property name.