### PR TITLE
feat: add ios and android store urls

### DIFF
--- a/schema-definitions/url.json
+++ b/schema-definitions/url.json
@@ -60,10 +60,10 @@
         "appA11yStatement": {
           "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
         },
-        "iosStoreLink": {
+        "iosStoreListing": {
           "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
         },
-        "androidStoreLink": {
+        "androidStoreListing": {
           "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
         }
       },

--- a/src/urls.ts
+++ b/src/urls.ts
@@ -9,8 +9,8 @@ export const ConfigurableLinks = z.object({
   flexTransportInfo: LanguageAndTextTypeArray.optional(),
   dataSharingInfo: LanguageAndTextTypeArray.optional(),
   appA11yStatement: LanguageAndTextTypeArray.optional(),
-  iosStoreLink: LanguageAndTextTypeArray.optional(),
-  androidStoreLink: LanguageAndTextTypeArray.optional(),
+  iosStoreListing: LanguageAndTextTypeArray.optional(),
+  androidStoreListing: LanguageAndTextTypeArray.optional(),
 });
 
 export type ConfigurableLinksType = z.infer<typeof ConfigurableLinks>;


### PR DESCRIPTION
When we want the user to update to the latest versoin of the app we want to provide them with a redirect to app / play store and these links should be stored in Firestore. 
This PR is linked to the discussion in: https://github.com/AtB-AS/mittatb-app/pull/4544#discussion_r1618355458

Closes: https://github.com/AtB-AS/kundevendt/issues/15380
