### PR TITLE
feat: add direction field to FareProductTypeConfig

### DIFF
--- a/schema-definitions/fareProductTypeConfigs.json
+++ b/schema-definitions/fareProductTypeConfigs.json
@@ -269,7 +269,7 @@
         },
         "direction": {
           "type": "string",
-          "enum": ["one-way","both"]
+          "enum": ["one-way","two-way"]
         }
       },
       "required": [

--- a/src/fare-product-type.ts
+++ b/src/fare-product-type.ts
@@ -44,7 +44,7 @@ export const OfferEndpoint = z.union([
 
 export const Direction = z.union([
   z.literal('one-way'),
-  z.literal('both'),
+  z.literal('two-way'),
 ]);
 
 export const ProductTypeTransportModes = z.object({


### PR DESCRIPTION
As part of https://github.com/AtB-AS/kundevendt/issues/15528, we need to keep track of the "direction" of fare products. Specifically to show info for boat tickets if it applies to a single trip in one direction or a periodic ticket that can be used both ways.

The field is optional, since it doesn't apply to zone based tickets.