### PR TITLE
feat: add external real-time map url

### DIFF
--- a/schema-definitions/url.json
+++ b/schema-definitions/url.json
@@ -65,6 +65,9 @@
         },
         "androidStoreListing": {
           "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
+        },
+        "externalRealtimeMap": {
+          "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
         }
       },
       "additionalProperties": false

--- a/src/urls.ts
+++ b/src/urls.ts
@@ -11,6 +11,7 @@ export const ConfigurableLinks = z.object({
   appA11yStatement: LanguageAndTextTypeArray.optional(),
   iosStoreListing: LanguageAndTextTypeArray.optional(),
   androidStoreListing: LanguageAndTextTypeArray.optional(),
+  externalRealtimeMap: LanguageAndTextTypeArray.optional(),
 });
 
 export type ConfigurableLinksType = z.infer<typeof ConfigurableLinks>;


### PR DESCRIPTION
Troms would like to add a link to their real-time map (https://kart.fylkestrafikk.no) and this is needed to solve that (https://github.com/AtB-AS/kundevendt/issues/18585). 