### PR TITLE
fix: prevent crash if no `$ref` in schema

### DIFF
--- a/src/tools/validate.ts
+++ b/src/tools/validate.ts
@@ -38,13 +38,13 @@ async function readSpecification(
   const spec = await readFile(join(BASE_FOLDER, `${filename}.json`));
   try {
     const parsed = JSON.parse(spec.toString());
-    const previous = ajv.getSchema(parsed['$ref']);
-
-    if (previous) {
-      return previous;
-    } else {
-      return ajv.compile(parsed);
+    if (parsed['$ref']) {
+      const previous = ajv.getSchema(parsed['$ref']);
+      if (previous) {
+        return previous;
+      }
     }
+    return ajv.compile(parsed);
   } catch (err) {
     throw new Error(`Unable to load or parse ${err}`);
   }


### PR DESCRIPTION
Previously, if `$ref` didn't exist, the script would crash

part of https://github.com/AtB-AS/kundevendt/issues/17087