### PR TITLE
feat: add --list-schemas cli option

### DIFF
--- a/src/tools/bin.ts
+++ b/src/tools/bin.ts
@@ -34,10 +34,20 @@ async function main() {
       ['file', 'schema'],
       'Please provide both scheme and file arguments',
     )
+    .option('list-schemas', {
+      alias: 'l',
+      describe: 'list all available schemas',
+      skipValidation: true,
+    })
     .help('h')
     .alias('h', 'help')
     .coerce('file', readAllFiles)
     .parse();
+
+  if (opts['list-schemas']) {
+    console.log(specifications.join('\n'));
+    process.exit(0);
+  }
 
   let error = 0;
   if (!opts?.file) {


### PR DESCRIPTION
Adds the `--list-schemas` CLI option, which is useful for scripting validation of firestore-configuration.

<img width="581" alt="Screenshot 2024-10-10 at 09 40 44" src="https://github.com/user-attachments/assets/c6559cb7-da8e-46fc-b521-e41773505cdc">

Putting this to use in https://github.com/AtB-AS/firestore-configuration/pull/667

part of https://github.com/AtB-AS/kundevendt/issues/17087