### PR TITLE
fix: constrain geometry type to "Polygon"

### DIFF
--- a/schema-definitions/referenceData.json
+++ b/schema-definitions/referenceData.json
@@ -156,7 +156,8 @@
             "type": "object",
             "properties": {
               "type": {
-                "type": "string"
+                "type": "string",
+                "const": "Polygon"
               },
               "coordinates": {
                 "type": "array",
@@ -272,7 +273,8 @@
             "type": "object",
             "properties": {
               "type": {
-                "type": "string"
+                "type": "string",
+                "const": "Polygon"
               },
               "coordinates": {
                 "type": "array",

--- a/src/reference-data.ts
+++ b/src/reference-data.ts
@@ -32,7 +32,7 @@ export const TariffZone = z.object({
   name: LanguageAndTextType,
   version: z.string(),
   geometry: z.object({
-    type: z.string(),
+    type: z.literal('Polygon'),
     coordinates: z.array(z.array(z.array(z.number()).length(2))),
   }),
   description: LanguageAndTextTypeArray.optional(),
@@ -47,7 +47,7 @@ export const CityZone = z.object({
   orderUrl: LanguageAndTextTypeArray.optional(),
   phoneNumber: z.string().optional(),
   geometry: z.object({
-    type: z.string(),
+    type: z.literal('Polygon'),
     coordinates: z.array(z.array(z.array(z.number()).length(2))),
   }),
 });


### PR DESCRIPTION
Since the app doesn't support other GeoJSON types, `geometry` should always have type "Polygon"