### PR TITLE
feat: Add mapboxSpriteUrl and tileServerBaseUrl

### DIFF
--- a/schema-definitions/urls.json
+++ b/schema-definitions/urls.json
@@ -65,6 +65,12 @@
         },
         "externalRealtimeMap": {
           "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
+        },
+        "tileServerBaseUrl": {
+          "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
+        },
+        "mapboxSpriteUrl": {
+          "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
         }
       },
       "additionalProperties": false

--- a/src/urls.ts
+++ b/src/urls.ts
@@ -12,6 +12,8 @@ export const ConfigurableLinks = z.object({
   iosStoreListing: LanguageAndTextTypeArray.optional(),
   androidStoreListing: LanguageAndTextTypeArray.optional(),
   externalRealtimeMap: LanguageAndTextTypeArray.optional(),
+  tileServerBaseUrl: LanguageAndTextTypeArray.optional(),
+  mapboxSpriteUrl: LanguageAndTextTypeArray.optional(),
 });
 
 export type ConfigurableLinksType = z.infer<typeof ConfigurableLinks>;


### PR DESCRIPTION
Following discussion with @gorandalum, we default to adding URLs in Firestore where we have better control over data refresh and types.

Resolves https://github.com/AtB-AS/kundevendt/issues/19555