### PR TITLE
Update readme since main is now protected

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,22 +99,27 @@ quality across Firestore, Webshop and App for all organisations involved.
 
 ## Release package
 
-After your changes are merged to the main branch:
+After your changes are merged to the main branch (which should include changes
+from `yarn build`):
 
-1. Checkout the latest changes on main branch
-2. Make sure you are authenticated through npm by running `npm whoami`
-3. Make sure your npm user has access to publish packages to AtB's npm repo.
-4. Run `yarn build` to build the package.
-5. Tag a new release by running `yarn version`:
+1. Create and checkout a new branch, e.g. called "yourfirstname/v-5-8-0".
+2. Run `yarn version` (which creates a new commit with updated version number in
+   package.json and creates a version tag):
 
 - **Major**: Breaking change. This version _require_ you to do code
   modifications after upgrading on the consumer side.
 - **Minor**: This version extends functionality.
 - **Patch**: This version affects no APIs at all, just changes to existing code.
 
-6. Run `npm publish` to publish the package to npm.
-7. Push to Github: `git push origin main`
-8. Push tags to Github: `git push origin main --tags`
+3. Push to Github: `git push origin yourfirstname/v-5-8-0` (replace with your
+   actual branch name).
+4. Push tags to Github: `git push origin yourfirstname/v-5-8-0 --tags` (replace
+   with your actual branch name).
+5. Create a PR for this new branch into main and merge when approved.
+6. Make sure you are authenticated through npm by running `npm whoami`.
+7. Make sure your npm user has access to publish packages to AtB's npm repo.
+8. Checkout and pull the updated main branch.
+9. run `npm publish` to publish the package to npm.
 
 _TODO: Packages should be automatically released when merging a PR created by
 `release-please-action` Github Action. Changelog and releases should


### PR DESCRIPTION
Update the readme for releasing since main is now protected and can't be pushed to directly.
The current process is a bit cumbersome to just publish a new version, so we should definitely automate this very soon.