### PR TITLE
feat: add FareZone definition and deprecates TariffZone

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ const selectedZone2: ZoneSelectionMode =
 enableTokenToggleRestrictions: true
 tokenToggleMaxLimit: 3
 defaultTariffZone: NOR:TariffZone:8040
+defaultFareZone: NOR:FareZone:8040
 vatPercent: 12
 ```
 

--- a/schema-definitions/fareProductTypeConfigs.json
+++ b/schema-definitions/fareProductTypeConfigs.json
@@ -256,6 +256,12 @@
             "type": "string"
           }
         },
+        "excludedFareZones": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "description": {
           "$ref": "#/definitions/FareProductTypeConfigSettings/properties/productSelectionTitle"
         },

--- a/schema-definitions/other.json
+++ b/schema-definitions/other.json
@@ -163,6 +163,9 @@
     "defaultTariffZone": {
       "type": "string"
     },
+    "defaultFareZone": {
+      "type": "string"
+    },
     "defaultOfferSearchMode": {
       "type": "string",
       "enum": ["zone", "stop-place"]

--- a/schema-definitions/referenceData.json
+++ b/schema-definitions/referenceData.json
@@ -65,6 +65,12 @@
                   "type": "string"
                 }
               },
+              "fareZoneRefs": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
               "appVersionMin": {
                 "type": "string"
               },
@@ -131,6 +137,54 @@
       }
     },
     "tariffZones": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "$ref": "#/properties/preassignedFareProducts_v2/items/properties/name"
+          },
+          "version": {
+            "type": "string"
+          },
+          "geometry": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "Polygon"
+              },
+              "coordinates": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            },
+            "required": ["type", "coordinates"],
+            "additionalProperties": false
+          },
+          "description": {
+            "$ref": "#/properties/preassignedFareProducts_v2/items/properties/alternativeNames"
+          },
+          "isDefault": {
+            "type": "boolean"
+          }
+        },
+        "required": ["id", "name", "version", "geometry"],
+        "additionalProperties": false
+      }
+    },
+    "fareZones": {
       "type": "array",
       "items": {
         "type": "object",
@@ -277,7 +331,7 @@
     },
     "preassignedFareProducts": {}
   },
-  "required": ["preassignedFareProducts_v2", "tariffZones", "userProfiles"],
+  "required": ["preassignedFareProducts_v2", "tariffZones", "fareZones", "userProfiles"],
   "additionalProperties": false,
   "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/src/fare-product-type.ts
+++ b/src/fare-product-type.ts
@@ -66,6 +66,7 @@ export const FareProductTypeConfig = z.object({
   name: LanguageAndTextTypeArray,
   transportModes: z.array(ProductTypeTransportModes),
   excludedTariffZones: z.array(z.string()).optional(),
+  excludedFareZones: z.array(z.string()).optional(),
   description: LanguageAndTextTypeArray,
   configuration: FareProductTypeConfigSettings,
   isCollectionOfAccesses: z.boolean(),

--- a/src/fare-product-type.ts
+++ b/src/fare-product-type.ts
@@ -65,6 +65,7 @@ export const FareProductTypeConfig = z.object({
   illustration: z.string().optional(),
   name: LanguageAndTextTypeArray,
   transportModes: z.array(ProductTypeTransportModes),
+  /** @deprecated use excludedFareZones instead */
   excludedTariffZones: z.array(z.string()).optional(),
   excludedFareZones: z.array(z.string()).optional(),
   description: LanguageAndTextTypeArray,

--- a/src/other.ts
+++ b/src/other.ts
@@ -26,6 +26,7 @@ export const Other = z.object({
     })
     .optional(),
   defaultTariffZone: z.string().optional(),
+  defaultFareZone: z.string().optional(),
   defaultOfferSearchMode: OfferSearchMode.optional(),
   disabledLoginMethods: z
     .object({

--- a/src/other.ts
+++ b/src/other.ts
@@ -25,6 +25,7 @@ export const Other = z.object({
       lon: z.number(),
     })
     .optional(),
+  /** @deprecated use defaultFareZone instead */
   defaultTariffZone: z.string().optional(),
   defaultFareZone: z.string().optional(),
   defaultOfferSearchMode: OfferSearchMode.optional(),

--- a/src/reference-data.ts
+++ b/src/reference-data.ts
@@ -10,9 +10,14 @@ export const PreassignedFareProduct = z.object({
   name: LanguageAndTextType,
   limitations: z.object({
     userProfileRefs: z.array(z.string()),
-    tariffZoneRefs: z.array(z.string()).optional(),
     appVersionMin: z.string().optional(),
     appVersionMax: z.string().optional(),
+    fareZoneRefs: z.array(z.string()).optional(),
+    
+    /**
+     * @deprecated use fareZoneRefs instead
+     */
+    tariffZoneRefs: z.array(z.string()).optional(),
   }),
   durationDays: z.number().optional(),
   isApplicableOnSingleZoneOnly: z.boolean().optional(),
@@ -26,7 +31,24 @@ export const PreassignedFareProduct = z.object({
   warningMessage: LanguageAndTextTypeArray.optional(),
 });
 
+/**
+ * @deprecated
+ * 
+ * Use {@link FareZone} instead
+ */
 export const TariffZone = z.object({
+  id: z.string(),
+  name: LanguageAndTextType,
+  version: z.string(),
+  geometry: z.object({
+    type: z.literal('Polygon'),
+    coordinates: z.array(z.array(z.array(z.number()).length(2))),
+  }),
+  description: LanguageAndTextTypeArray.optional(),
+  isDefault: z.boolean().optional(),
+});
+
+export const FareZone = z.object({
   id: z.string(),
   name: LanguageAndTextType,
   version: z.string(),
@@ -68,7 +90,7 @@ export const UserProfile = z.object({
 
 export const ReferenceData = z.object({
   preassignedFareProducts_v2: z.array(PreassignedFareProduct),
-  tariffZones: z.array(TariffZone),
+  fareZones: z.array(FareZone),
   userProfiles: z.array(UserProfile),
   cityZones: z.array(CityZone).optional(),
 
@@ -76,10 +98,20 @@ export const ReferenceData = z.object({
    * @deprecated Use preassignedFareProducts_v2 instead
    */
   preassignedFareProducts: z.any(),
+
+  /**
+   * @deprecated Use fareZones instead
+   */
+  tariffZones: z.array(TariffZone),
+  
 });
 
 export type PreassignedFareProduct = z.infer<typeof PreassignedFareProduct>;
+
+/** @deprecated Use {@link FareZone} instead */
 export type TariffZone = z.infer<typeof TariffZone>;
+
+export type FareZone = z.infer<typeof FareZone>;
 export type CityZone = z.infer<typeof CityZone>;
 export type UserProfile = z.infer<typeof UserProfile>;
 export type ReferenceData = z.infer<typeof ReferenceData>;

--- a/src/tests/fixtures/referenceData.json
+++ b/src/tests/fixtures/referenceData.json
@@ -28,6 +28,20 @@
       }
     }
   ],
+  "fareZones": [
+    {
+      "id": "ATB:FareZone:10",
+      "name": {
+        "lang": "nor",
+        "value": "A"
+      },
+      "version": "4",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[[10.73617214148, 63.31324444455]]]
+      }
+    }
+  ],
   "userProfiles": [
     {
       "id": "ATB:UserProfile:8ee842e3",


### PR DESCRIPTION
part of https://github.com/AtB-AS/kundevendt/issues/20567

- added `FareZone` and it's variant (defaultFareZone, excludedFareZone) to the definition
- deprecated the usage of `TariffZone`

TariffZone is still there to support the legacy versions, but will be removed in 2026