### PR TITLE
feat: add transportSubMode for the AtB Bestill

### DIFF
--- a/schema-definitions/travelSearchFilters.json
+++ b/schema-definitions/travelSearchFilters.json
@@ -71,6 +71,7 @@
               "allFunicularServices",
               "allHireVehicles",
               "allTaxiServices",
+              "atbBookingBus",
               "bikeTaxi",
               "blackCab",
               "cableCar",


### PR DESCRIPTION
A new transport submode for 'Atb Bestill' for the search filter in this task  https://github.com/AtB-AS/kundevendt/issues/20180.

