### PR TITLE
refactor: make the fareZones optional for now, until all the data is ready

### DIFF
--- a/schema-definitions/referenceData.json
+++ b/schema-definitions/referenceData.json
@@ -331,12 +331,7 @@
       }
     }
   },
-  "required": [
-    "preassignedFareProducts_v2",
-    "fareZones",
-    "userProfiles",
-    "tariffZones"
-  ],
+  "required": ["preassignedFareProducts_v2", "userProfiles", "tariffZones"],
   "additionalProperties": false,
   "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/src/reference-data.ts
+++ b/src/reference-data.ts
@@ -90,7 +90,7 @@ export const UserProfile = z.object({
 
 export const ReferenceData = z.object({
   preassignedFareProducts_v2: z.array(PreassignedFareProduct),
-  fareZones: z.array(FareZone),
+  fareZones: z.array(FareZone).optional(),
   userProfiles: z.array(UserProfile),
   cityZones: z.array(CityZone).optional(),
 


### PR DESCRIPTION
Firestore config shows error during validation because not all OMS data on Staging and Prod has `fareZones` on their `referenceData`, so the `fareZones` are made optional until all the data is ready.