### PR TITLE
feat: add fare zones to bonus source

### DIFF
--- a/schema-definitions/mobility.json
+++ b/schema-definitions/mobility.json
@@ -314,6 +314,12 @@
                   "type": "string"
                 }
               },
+              "fareZones": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
               "amountByEnrollment": {
                 "type": "array",
                 "items": {
@@ -336,6 +342,7 @@
               "id",
               "preassignedFareProductId",
               "userProfileIds",
+              "fareZones",
               "amountByEnrollment"
             ],
             "additionalProperties": false

--- a/src/mobility.ts
+++ b/src/mobility.ts
@@ -99,6 +99,7 @@ export const BonusSource = z.object({
   id: z.string(),
   preassignedFareProductId: z.string(),
   userProfileIds: z.array(z.string()),
+  fareZones: z.array(z.string()),
   amountByEnrollment: z.array(
     z.object({
       enrollmentId: z.string().optional(), // which enrollment (pilot group) a user is in


### PR DESCRIPTION
adds farezones to bonus source to enable limiting which zones give bonus points