### PR TITLE
feat: add bonus onboarding screens data

### DIFF
--- a/schema-definitions/mobility.json
+++ b/schema-definitions/mobility.json
@@ -154,6 +154,21 @@
               "isDeepIntegrationEnabled": {
                 "type": "boolean",
                 "default": false
+              },
+              "appUrl": {
+                "type": "object",
+                "properties": {
+                  "ios": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "android": {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                },
+                "required": ["ios", "android"],
+                "additionalProperties": false
               }
             },
             "required": ["id", "name", "formFactors"],
@@ -292,9 +307,70 @@
           "properties": {
             "howBonusWorks": {
               "$ref": "#/definitions/MobilityOperator/properties/bonusProducts/items/properties/productDescription"
+            },
+            "onboardingScreens": {
+              "type": "object",
+              "properties": {
+                "welcome": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "$ref": "#/definitions/MobilityOperator/properties/scooterFaqs/items/properties/title"
+                    },
+                    "description": {
+                      "$ref": "#/definitions/MobilityOperator/properties/scooterFaqs/items/properties/description"
+                    },
+                    "buttonText": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/MobilityOperator/properties/operators/items/properties/benefits/items/properties/headingWhenActive/items"
+                      },
+                      "minItems": 1
+                    }
+                  },
+                  "required": ["title", "description", "buttonText"],
+                  "additionalProperties": false
+                },
+                "buyTickets": {
+                  "$ref": "#/definitions/MobilityOperator/properties/bonusTexts/properties/onboardingScreens/properties/welcome"
+                },
+                "moreTravelOptions": {
+                  "$ref": "#/definitions/MobilityOperator/properties/bonusTexts/properties/onboardingScreens/properties/welcome"
+                },
+                "download": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "$ref": "#/definitions/MobilityOperator/properties/scooterFaqs/items/properties/title"
+                    },
+                    "description": {
+                      "$ref": "#/definitions/MobilityOperator/properties/scooterFaqs/items/properties/description"
+                    },
+                    "buttonText": {
+                      "$ref": "#/definitions/MobilityOperator/properties/bonusTexts/properties/onboardingScreens/properties/welcome/properties/buttonText"
+                    },
+                    "downloadMobilityOperatorIds": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    }
+                  },
+                  "required": ["title", "description", "buttonText"],
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "welcome",
+                "buyTickets",
+                "moreTravelOptions",
+                "download"
+              ],
+              "additionalProperties": false
             }
           },
-          "required": ["howBonusWorks"],
+          "required": ["howBonusWorks", "onboardingScreens"],
           "additionalProperties": false
         },
         "bonusSources": {

--- a/src/mobility.ts
+++ b/src/mobility.ts
@@ -89,8 +89,33 @@ export const BonusProduct = z.object({
 
 export type BonusProductType = z.infer<typeof BonusProduct>;
 
+export const OnboardingScreenData = titleAndDescription.extend({
+  buttonText: LanguageAndTextTypeArray.nonempty(),
+});
+
+export type OnboardingScreenDataType = z.infer<typeof OnboardingScreenData>;
+
 export const BonusTexts = z.object({
   howBonusWorks: titleAndDescription,
+  onboardingScreens: z.object({
+    welcome: OnboardingScreenData,
+    buyTickets: OnboardingScreenData,
+    moreTravelOptions: OnboardingScreenData,
+    download: OnboardingScreenData.extend({
+      downloadOperators: z
+        .array(
+          z.object({
+            operatorId: z.string(),
+            operatorName: z.string(),
+            downloadLinks: z.object({
+              ios: z.string(),
+              android: z.string(),
+            }),
+          }),
+        )
+        .optional(),
+    }),
+  }),
 });
 
 export type BonusTextsType = z.infer<typeof BonusTexts>;

--- a/src/mobility.ts
+++ b/src/mobility.ts
@@ -54,6 +54,12 @@ export const MobilityOperator = z.object({
     .optional()
     .describe('modeled 1-1 like brandAssets in EnTur mobility API'),
   isDeepIntegrationEnabled: z.boolean().default(false),
+  appUrl: z
+    .object({
+      ios: z.string().url(),
+      android: z.string().url(),
+    })
+    .optional(),
 });
 
 export type MobilityOperatorType = z.infer<typeof MobilityOperator>;
@@ -102,18 +108,7 @@ export const BonusTexts = z.object({
     buyTickets: OnboardingScreenData,
     moreTravelOptions: OnboardingScreenData,
     download: OnboardingScreenData.extend({
-      downloadOperators: z
-        .array(
-          z.object({
-            operatorId: z.string(),
-            operatorName: z.string(),
-            downloadLinks: z.object({
-              ios: z.string(),
-              android: z.string(),
-            }),
-          }),
-        )
-        .optional(),
+      downloadMobilityOperatorIds: z.array(z.string().nonempty()).optional(),
     }),
   }),
 });


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/20660

Adds all texts and info that will be used for onboarding screens

Creates a basic OnboardingScreenDataType that is reused for all onboarding screens. Extends this when needed.