### PR TITLE
feat: add age limit to mobility operators

### DIFF
--- a/schema-definitions/mobility.json
+++ b/schema-definitions/mobility.json
@@ -157,8 +157,7 @@
               },
               "ageLimit": {
                 "type": "integer",
-                "exclusiveMinimum": 0,
-                "default": 18
+                "exclusiveMinimum": 0
               },
               "appUrl": {
                 "type": "object",

--- a/schema-definitions/mobility.json
+++ b/schema-definitions/mobility.json
@@ -155,6 +155,11 @@
                 "type": "boolean",
                 "default": false
               },
+              "ageLimit": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "default": 18
+              },
               "appUrl": {
                 "type": "object",
                 "properties": {

--- a/src/mobility.ts
+++ b/src/mobility.ts
@@ -54,6 +54,7 @@ export const MobilityOperator = z.object({
     .optional()
     .describe('modeled 1-1 like brandAssets in EnTur mobility API'),
   isDeepIntegrationEnabled: z.boolean().default(false),
+  ageLimit: z.number().int().positive().default(18),
   appUrl: z
     .object({
       ios: z.string().url(),

--- a/src/mobility.ts
+++ b/src/mobility.ts
@@ -54,7 +54,7 @@ export const MobilityOperator = z.object({
     .optional()
     .describe('modeled 1-1 like brandAssets in EnTur mobility API'),
   isDeepIntegrationEnabled: z.boolean().default(false),
-  ageLimit: z.number().int().positive().default(18),
+  ageLimit: z.number().int().positive().optional(),
   appUrl: z
     .object({
       ios: z.string().url(),


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/21511

adds age limit value to mobility operators

value defaults to 18, but can be overrided in firestore-config