### PR TITLE
feat: add isEnabledForTripSearchOffer to PreassignedFareProduct

### DIFF
--- a/schema-definitions/referenceData.json
+++ b/schema-definitions/referenceData.json
@@ -104,7 +104,7 @@
           "isBookingEnabled": {
             "type": ["boolean", "null"]
           },
-          "isEnabledForOfferFromLegs": {
+          "isEnabledForTripSearchOffer": {
             "type": ["boolean", "null"]
           },
           "isDefault": {

--- a/src/reference-data.ts
+++ b/src/reference-data.ts
@@ -26,7 +26,10 @@ export const PreassignedFareProduct = z.object({
     .nullish()
     .transform(nullishToOptional),
   isBookingEnabled: z.boolean().nullish().transform(nullishToOptional),
-  isEnabledForOfferFromLegs: z.boolean().nullish().transform(nullishToOptional),
+  isEnabledForTripSearchOffer: z
+    .boolean()
+    .nullish()
+    .transform(nullishToOptional),
   isDefault: z.boolean().nullish().transform(nullishToOptional),
   alternativeNames:
     LanguageAndTextTypeArray.nullish().transform(nullishToOptional),


### PR DESCRIPTION
In order to determine whether a preassignedFareProduct is eligible for getting offerFromLegs or not, add `isEnabledForTripSearchOffer`.

Part of https://github.com/AtB-AS/kundevendt/issues/20029