### PR TITLE
feat: add SP&R read more URL

### DIFF
--- a/schema-definitions/urls.json
+++ b/schema-definitions/urls.json
@@ -83,6 +83,9 @@
         },
         "frequentlyAskedQuestionsUrl": {
           "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
+        },
+        "sparReadMoreUrl": {
+          "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
         }
       },
       "additionalProperties": false

--- a/src/urls.ts
+++ b/src/urls.ts
@@ -18,6 +18,7 @@ export const ConfigurableLinks = z.object({
   contactFormUrl: LanguageAndTextTypeArray.optional(),
   lostAndFoundUrl: LanguageAndTextTypeArray.optional(),
   frequentlyAskedQuestionsUrl: LanguageAndTextTypeArray.optional(),
+  sparReadMoreUrl: LanguageAndTextTypeArray.optional(),
 });
 
 export type ConfigurableLinksType = z.infer<typeof ConfigurableLinks>;


### PR DESCRIPTION
Introduce an optional URL for the SP&R read more section in the configurable links.