### PR TITLE
feat!: zod and node upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
   "devDependencies": {
     "@swc-node/register": "^1.6.2",
     "@swc/core": "^1.3.44",
-    "@tsconfig/recommended": "^1.0.2",
+    "@tsconfig/node22": "^22.0.2",
     "@types/js-yaml": "^4.0.5",
     "@types/node": "^18.15.11",
     "@types/yargs": "^17.0.24",
     "prettier": "^3.2.5",
     "rimraf": "^4.4.1",
-    "typescript": "^5.0.2",
+    "typescript": "^5.9.2",
     "vitest": "^0.29.8"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,15 +35,17 @@
     "prettier": "^3.2.5",
     "rimraf": "^4.4.1",
     "typescript": "^5.9.2",
-    "vitest": "^0.29.8"
+    "vitest": "^0.29.8",
+    "zod": "^4.1.11"
   },
   "dependencies": {
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "glob": "^9.3.2",
     "js-yaml": "^4.1.0",
-    "yargs": "^17.7.1",
-    "zod": "^3.24.4",
-    "zod-to-json-schema": "^3.24.5"
+    "yargs": "^17.7.1"
+  },
+  "peerDependencies": {
+    "zod": "^4.1.11"
   }
 }

--- a/schema-definitions/consents.json
+++ b/schema-definitions/consents.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "properties": {
     "consents": {
@@ -48,6 +49,5 @@
     }
   },
   "required": ["consents"],
-  "additionalProperties": false,
-  "$schema": "http://json-schema.org/draft-07/schema#"
+  "additionalProperties": false
 }

--- a/schema-definitions/fareProductTypeConfigs.json
+++ b/schema-definitions/fareProductTypeConfigs.json
@@ -1,335 +1,1407 @@
 {
-  "$ref": "#/definitions/FareProductConfiguration",
-  "definitions": {
-    "LanguageAndTextType": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "lang": {
-              "type": "string"
-            },
-            "value": {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "FareProductConfiguration",
+  "type": "object",
+  "properties": {
+    "fareProductTypeConfigs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "illustration": {
+            "type": "string"
+          },
+          "name": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "lang": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["lang", "value"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "language": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
+          },
+          "transportModes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "const": "bicycle"
+                    },
+                    {
+                      "type": "string",
+                      "const": "foot"
+                    },
+                    {
+                      "type": "string",
+                      "const": "scooter"
+                    },
+                    {
+                      "type": "string",
+                      "const": "air"
+                    },
+                    {
+                      "type": "string",
+                      "const": "bus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "cableway"
+                    },
+                    {
+                      "type": "string",
+                      "const": "coach"
+                    },
+                    {
+                      "type": "string",
+                      "const": "funicular"
+                    },
+                    {
+                      "type": "string",
+                      "const": "lift"
+                    },
+                    {
+                      "type": "string",
+                      "const": "metro"
+                    },
+                    {
+                      "type": "string",
+                      "const": "monorail"
+                    },
+                    {
+                      "type": "string",
+                      "const": "rail"
+                    },
+                    {
+                      "type": "string",
+                      "const": "taxi"
+                    },
+                    {
+                      "type": "string",
+                      "const": "tram"
+                    },
+                    {
+                      "type": "string",
+                      "const": "trolleybus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "unknown"
+                    },
+                    {
+                      "type": "string",
+                      "const": "water"
+                    }
+                  ]
+                },
+                "subMode": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "const": "escooter"
+                    },
+                    {
+                      "type": "string",
+                      "const": "SchengenAreaFlight"
+                    },
+                    {
+                      "type": "string",
+                      "const": "airportBoatLink"
+                    },
+                    {
+                      "type": "string",
+                      "const": "airportLinkBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "airportLinkRail"
+                    },
+                    {
+                      "type": "string",
+                      "const": "airshipService"
+                    },
+                    {
+                      "type": "string",
+                      "const": "allFunicularServices"
+                    },
+                    {
+                      "type": "string",
+                      "const": "allHireVehicles"
+                    },
+                    {
+                      "type": "string",
+                      "const": "allTaxiServices"
+                    },
+                    {
+                      "type": "string",
+                      "const": "bikeTaxi"
+                    },
+                    {
+                      "type": "string",
+                      "const": "blackCab"
+                    },
+                    {
+                      "type": "string",
+                      "const": "cableCar"
+                    },
+                    {
+                      "type": "string",
+                      "const": "cableFerry"
+                    },
+                    {
+                      "type": "string",
+                      "const": "canalBarge"
+                    },
+                    {
+                      "type": "string",
+                      "const": "carTransportRailService"
+                    },
+                    {
+                      "type": "string",
+                      "const": "chairLift"
+                    },
+                    {
+                      "type": "string",
+                      "const": "charterTaxi"
+                    },
+                    {
+                      "type": "string",
+                      "const": "cityTram"
+                    },
+                    {
+                      "type": "string",
+                      "const": "communalTaxi"
+                    },
+                    {
+                      "type": "string",
+                      "const": "commuterCoach"
+                    },
+                    {
+                      "type": "string",
+                      "const": "crossCountryRail"
+                    },
+                    {
+                      "type": "string",
+                      "const": "dedicatedLaneBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "demandAndResponseBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "domesticCharterFlight"
+                    },
+                    {
+                      "type": "string",
+                      "const": "domesticFlight"
+                    },
+                    {
+                      "type": "string",
+                      "const": "domesticScheduledFlight"
+                    },
+                    {
+                      "type": "string",
+                      "const": "dragLift"
+                    },
+                    {
+                      "type": "string",
+                      "const": "expressBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "funicular"
+                    },
+                    {
+                      "type": "string",
+                      "const": "helicopterService"
+                    },
+                    {
+                      "type": "string",
+                      "const": "highFrequencyBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "highSpeedPassengerService"
+                    },
+                    {
+                      "type": "string",
+                      "const": "highSpeedRail"
+                    },
+                    {
+                      "type": "string",
+                      "const": "highSpeedVehicleService"
+                    },
+                    {
+                      "type": "string",
+                      "const": "hireCar"
+                    },
+                    {
+                      "type": "string",
+                      "const": "hireCycle"
+                    },
+                    {
+                      "type": "string",
+                      "const": "hireMotorbike"
+                    },
+                    {
+                      "type": "string",
+                      "const": "hireVan"
+                    },
+                    {
+                      "type": "string",
+                      "const": "intercontinentalCharterFlight"
+                    },
+                    {
+                      "type": "string",
+                      "const": "intercontinentalFlight"
+                    },
+                    {
+                      "type": "string",
+                      "const": "international"
+                    },
+                    {
+                      "type": "string",
+                      "const": "internationalCarFerry"
+                    },
+                    {
+                      "type": "string",
+                      "const": "internationalCharterFlight"
+                    },
+                    {
+                      "type": "string",
+                      "const": "internationalCoach"
+                    },
+                    {
+                      "type": "string",
+                      "const": "internationalFlight"
+                    },
+                    {
+                      "type": "string",
+                      "const": "internationalPassengerFerry"
+                    },
+                    {
+                      "type": "string",
+                      "const": "interregionalRail"
+                    },
+                    {
+                      "type": "string",
+                      "const": "lift"
+                    },
+                    {
+                      "type": "string",
+                      "const": "local"
+                    },
+                    {
+                      "type": "string",
+                      "const": "localBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "localCarFerry"
+                    },
+                    {
+                      "type": "string",
+                      "const": "localPassengerFerry"
+                    },
+                    {
+                      "type": "string",
+                      "const": "localTram"
+                    },
+                    {
+                      "type": "string",
+                      "const": "longDistance"
+                    },
+                    {
+                      "type": "string",
+                      "const": "metro"
+                    },
+                    {
+                      "type": "string",
+                      "const": "miniCab"
+                    },
+                    {
+                      "type": "string",
+                      "const": "mobilityBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "mobilityBusForRegisteredDisabled"
+                    },
+                    {
+                      "type": "string",
+                      "const": "nationalCarFerry"
+                    },
+                    {
+                      "type": "string",
+                      "const": "nationalCoach"
+                    },
+                    {
+                      "type": "string",
+                      "const": "nationalPassengerFerry"
+                    },
+                    {
+                      "type": "string",
+                      "const": "nightBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "nightRail"
+                    },
+                    {
+                      "type": "string",
+                      "const": "postBoat"
+                    },
+                    {
+                      "type": "string",
+                      "const": "postBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "rackAndPinionRailway"
+                    },
+                    {
+                      "type": "string",
+                      "const": "railReplacementBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "railShuttle"
+                    },
+                    {
+                      "type": "string",
+                      "const": "railTaxi"
+                    },
+                    {
+                      "type": "string",
+                      "const": "regionalBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "regionalCarFerry"
+                    },
+                    {
+                      "type": "string",
+                      "const": "regionalCoach"
+                    },
+                    {
+                      "type": "string",
+                      "const": "regionalPassengerFerry"
+                    },
+                    {
+                      "type": "string",
+                      "const": "regionalRail"
+                    },
+                    {
+                      "type": "string",
+                      "const": "regionalTram"
+                    },
+                    {
+                      "type": "string",
+                      "const": "replacementRailService"
+                    },
+                    {
+                      "type": "string",
+                      "const": "riverBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "roadFerryLink"
+                    },
+                    {
+                      "type": "string",
+                      "const": "roundTripCharterFlight"
+                    },
+                    {
+                      "type": "string",
+                      "const": "scheduledFerry"
+                    },
+                    {
+                      "type": "string",
+                      "const": "schoolAndPublicServiceBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "schoolBoat"
+                    },
+                    {
+                      "type": "string",
+                      "const": "schoolBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "schoolCoach"
+                    },
+                    {
+                      "type": "string",
+                      "const": "shortHaulInternationalFlight"
+                    },
+                    {
+                      "type": "string",
+                      "const": "shuttleBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "shuttleCoach"
+                    },
+                    {
+                      "type": "string",
+                      "const": "shuttleFerryService"
+                    },
+                    {
+                      "type": "string",
+                      "const": "shuttleFlight"
+                    },
+                    {
+                      "type": "string",
+                      "const": "shuttleTram"
+                    },
+                    {
+                      "type": "string",
+                      "const": "sightseeingBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "sightseeingCoach"
+                    },
+                    {
+                      "type": "string",
+                      "const": "sightseeingFlight"
+                    },
+                    {
+                      "type": "string",
+                      "const": "sightseeingService"
+                    },
+                    {
+                      "type": "string",
+                      "const": "sightseeingTram"
+                    },
+                    {
+                      "type": "string",
+                      "const": "sleeperRailService"
+                    },
+                    {
+                      "type": "string",
+                      "const": "specialCoach"
+                    },
+                    {
+                      "type": "string",
+                      "const": "specialNeedsBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "specialTrain"
+                    },
+                    {
+                      "type": "string",
+                      "const": "streetCableCar"
+                    },
+                    {
+                      "type": "string",
+                      "const": "suburbanRailway"
+                    },
+                    {
+                      "type": "string",
+                      "const": "telecabin"
+                    },
+                    {
+                      "type": "string",
+                      "const": "telecabinLink"
+                    },
+                    {
+                      "type": "string",
+                      "const": "touristCoach"
+                    },
+                    {
+                      "type": "string",
+                      "const": "touristRailway"
+                    },
+                    {
+                      "type": "string",
+                      "const": "trainFerry"
+                    },
+                    {
+                      "type": "string",
+                      "const": "trainTram"
+                    },
+                    {
+                      "type": "string",
+                      "const": "tube"
+                    },
+                    {
+                      "type": "string",
+                      "const": "undefined"
+                    },
+                    {
+                      "type": "string",
+                      "const": "undefinedFunicular"
+                    },
+                    {
+                      "type": "string",
+                      "const": "unknown"
+                    },
+                    {
+                      "type": "string",
+                      "const": "urbanRailway"
+                    },
+                    {
+                      "type": "string",
+                      "const": "waterTaxi"
+                    }
+                  ]
+                }
+              },
+              "required": ["mode"],
+              "additionalProperties": false
+            }
+          },
+          "excludedTariffZones": {
+            "type": "array",
+            "items": {
               "type": "string"
             }
           },
-          "required": ["lang", "value"],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "language": {
-              "type": "string"
-            },
-            "value": {
+          "excludedFareZones": {
+            "type": "array",
+            "items": {
               "type": "string"
             }
           },
-          "additionalProperties": false
-        }
-      ]
-    },
-    "ProductTypeTransportModes": {
-      "type": "object",
-      "properties": {
-        "mode": {
-          "$ref": "#/definitions/TransportModeType"
-        },
-        "subMode": {
-          "$ref": "#/definitions/TransportSubmodeType"
-        }
-      },
-      "required": ["mode"],
-      "additionalProperties": false
-    },
-    "FareProductTypeConfigSettings": {
-      "type": "object",
-      "properties": {
-        "zoneSelectionMode": {
-          "type": "string",
-          "enum": [
-            "none",
-            "single",
-            "single-stop",
-            "single-zone",
-            "multiple",
-            "multiple-stop",
-            "multiple-zone",
-            "multiple-stop-harbor"
-          ]
-        },
-        "travellerSelectionMode": {
-          "type": "string",
-          "enum": ["multiple", "single", "none"]
-        },
-        "timeSelectionMode": {
-          "type": "string",
-          "enum": ["datetime", "next-morning", "next-morning-minimum", "none"]
-        },
-        "productSelectionMode": {
-          "type": "string",
-          "enum": ["duration", "product", "productAlias", "none"]
-        },
-        "productSelectionTitle": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/LanguageAndTextType"
-          }
-        },
-        "requiresLogin": {
-          "type": "boolean"
-        },
-        "offerEndpoint": {
-          "type": "string",
-          "enum": ["zones", "stop-places", "authority"]
-        },
-        "onBehalfOfEnabled": {
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "zoneSelectionMode",
-        "travellerSelectionMode",
-        "timeSelectionMode",
-        "productSelectionMode",
-        "requiresLogin",
-        "onBehalfOfEnabled"
-      ],
-      "additionalProperties": false
-    },
-    "FareProductTypeConfig": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string"
-        },
-        "illustration": {
-          "type": "string"
-        },
-        "name": {
-          "$ref": "#/definitions/FareProductTypeConfigSettings/properties/productSelectionTitle"
-        },
-        "transportModes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ProductTypeTransportModes"
-          }
-        },
-        "excludedTariffZones": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "excludedFareZones": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "description": {
-          "$ref": "#/definitions/FareProductTypeConfigSettings/properties/productSelectionTitle"
-        },
-        "configuration": {
-          "$ref": "#/definitions/FareProductTypeConfigSettings"
-        },
-        "isCollectionOfAccesses": {
-          "type": "boolean"
-        },
-        "direction": {
-          "type": "string",
-          "enum": ["one-way", "two-way"]
-        }
-      },
-      "required": [
-        "type",
-        "name",
-        "transportModes",
-        "description",
-        "configuration",
-        "isCollectionOfAccesses"
-      ],
-      "additionalProperties": false
-    },
-    "TransportModeType": {
-      "type": "string",
-      "enum": [
-        "bicycle",
-        "foot",
-        "scooter",
-        "air",
-        "bus",
-        "cableway",
-        "coach",
-        "funicular",
-        "lift",
-        "metro",
-        "monorail",
-        "rail",
-        "taxi",
-        "tram",
-        "trolleybus",
-        "unknown",
-        "water"
-      ]
-    },
-    "TransportSubmodeType": {
-      "type": "string",
-      "enum": [
-        "escooter",
-        "SchengenAreaFlight",
-        "airportBoatLink",
-        "airportLinkBus",
-        "airportLinkRail",
-        "airshipService",
-        "allFunicularServices",
-        "allHireVehicles",
-        "allTaxiServices",
-        "bikeTaxi",
-        "blackCab",
-        "cableCar",
-        "cableFerry",
-        "canalBarge",
-        "carTransportRailService",
-        "chairLift",
-        "charterTaxi",
-        "cityTram",
-        "communalTaxi",
-        "commuterCoach",
-        "crossCountryRail",
-        "dedicatedLaneBus",
-        "demandAndResponseBus",
-        "domesticCharterFlight",
-        "domesticFlight",
-        "domesticScheduledFlight",
-        "dragLift",
-        "expressBus",
-        "funicular",
-        "helicopterService",
-        "highFrequencyBus",
-        "highSpeedPassengerService",
-        "highSpeedRail",
-        "highSpeedVehicleService",
-        "hireCar",
-        "hireCycle",
-        "hireMotorbike",
-        "hireVan",
-        "intercontinentalCharterFlight",
-        "intercontinentalFlight",
-        "international",
-        "internationalCarFerry",
-        "internationalCharterFlight",
-        "internationalCoach",
-        "internationalFlight",
-        "internationalPassengerFerry",
-        "interregionalRail",
-        "lift",
-        "local",
-        "localBus",
-        "localCarFerry",
-        "localPassengerFerry",
-        "localTram",
-        "longDistance",
-        "metro",
-        "miniCab",
-        "mobilityBus",
-        "mobilityBusForRegisteredDisabled",
-        "nationalCarFerry",
-        "nationalCoach",
-        "nationalPassengerFerry",
-        "nightBus",
-        "nightRail",
-        "postBoat",
-        "postBus",
-        "rackAndPinionRailway",
-        "railReplacementBus",
-        "railShuttle",
-        "railTaxi",
-        "regionalBus",
-        "regionalCarFerry",
-        "regionalCoach",
-        "regionalPassengerFerry",
-        "regionalRail",
-        "regionalTram",
-        "replacementRailService",
-        "riverBus",
-        "roadFerryLink",
-        "roundTripCharterFlight",
-        "scheduledFerry",
-        "schoolAndPublicServiceBus",
-        "schoolBoat",
-        "schoolBus",
-        "schoolCoach",
-        "shortHaulInternationalFlight",
-        "shuttleBus",
-        "shuttleCoach",
-        "shuttleFerryService",
-        "shuttleFlight",
-        "shuttleTram",
-        "sightseeingBus",
-        "sightseeingCoach",
-        "sightseeingFlight",
-        "sightseeingService",
-        "sightseeingTram",
-        "sleeperRailService",
-        "specialCoach",
-        "specialNeedsBus",
-        "specialTrain",
-        "streetCableCar",
-        "suburbanRailway",
-        "telecabin",
-        "telecabinLink",
-        "touristCoach",
-        "touristRailway",
-        "trainFerry",
-        "trainTram",
-        "tube",
-        "undefined",
-        "undefinedFunicular",
-        "unknown",
-        "urbanRailway",
-        "waterTaxi"
-      ]
-    },
-    "FareProductConfiguration": {
-      "type": "object",
-      "properties": {
-        "fareProductTypeConfigs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/FareProductTypeConfig"
-          }
-        },
-        "fareProductGroups": {
-          "type": "array",
-          "items": {
+          "description": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "lang": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["lang", "value"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "language": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
+          },
+          "configuration": {
             "type": "object",
             "properties": {
-              "transportModes": {
+              "zoneSelectionMode": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "const": "none"
+                  },
+                  {
+                    "type": "string",
+                    "const": "single"
+                  },
+                  {
+                    "type": "string",
+                    "const": "single-stop"
+                  },
+                  {
+                    "type": "string",
+                    "const": "single-zone"
+                  },
+                  {
+                    "type": "string",
+                    "const": "multiple"
+                  },
+                  {
+                    "type": "string",
+                    "const": "multiple-stop"
+                  },
+                  {
+                    "type": "string",
+                    "const": "multiple-zone"
+                  },
+                  {
+                    "type": "string",
+                    "const": "multiple-stop-harbor"
+                  }
+                ]
+              },
+              "travellerSelectionMode": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "const": "multiple"
+                  },
+                  {
+                    "type": "string",
+                    "const": "single"
+                  },
+                  {
+                    "type": "string",
+                    "const": "none"
+                  }
+                ]
+              },
+              "timeSelectionMode": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "const": "datetime"
+                  },
+                  {
+                    "type": "string",
+                    "const": "next-morning"
+                  },
+                  {
+                    "type": "string",
+                    "const": "next-morning-minimum"
+                  },
+                  {
+                    "type": "string",
+                    "const": "none"
+                  }
+                ]
+              },
+              "productSelectionMode": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "const": "duration"
+                  },
+                  {
+                    "type": "string",
+                    "const": "product"
+                  },
+                  {
+                    "type": "string",
+                    "const": "productAlias"
+                  },
+                  {
+                    "type": "string",
+                    "const": "none"
+                  }
+                ]
+              },
+              "productSelectionTitle": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/definitions/ProductTypeTransportModes"
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "lang": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["lang", "value"],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "language": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ]
                 }
               },
-              "types": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
+              "requiresLogin": {
+                "type": "boolean"
               },
-              "heading": {
-                "$ref": "#/definitions/FareProductTypeConfigSettings/properties/productSelectionTitle"
+              "offerEndpoint": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "const": "zones"
+                  },
+                  {
+                    "type": "string",
+                    "const": "stop-places"
+                  },
+                  {
+                    "type": "string",
+                    "const": "authority"
+                  }
+                ]
+              },
+              "onBehalfOfEnabled": {
+                "type": "boolean"
               }
             },
-            "required": ["transportModes", "types"],
+            "required": [
+              "zoneSelectionMode",
+              "travellerSelectionMode",
+              "timeSelectionMode",
+              "productSelectionMode",
+              "requiresLogin",
+              "onBehalfOfEnabled"
+            ],
             "additionalProperties": false
+          },
+          "isCollectionOfAccesses": {
+            "type": "boolean"
+          },
+          "direction": {
+            "anyOf": [
+              {
+                "type": "string",
+                "const": "one-way"
+              },
+              {
+                "type": "string",
+                "const": "two-way"
+              }
+            ]
           }
-        }
-      },
-      "required": ["fareProductTypeConfigs"],
-      "additionalProperties": false
+        },
+        "required": [
+          "type",
+          "name",
+          "transportModes",
+          "description",
+          "configuration",
+          "isCollectionOfAccesses"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "fareProductGroups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "transportModes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "const": "bicycle"
+                    },
+                    {
+                      "type": "string",
+                      "const": "foot"
+                    },
+                    {
+                      "type": "string",
+                      "const": "scooter"
+                    },
+                    {
+                      "type": "string",
+                      "const": "air"
+                    },
+                    {
+                      "type": "string",
+                      "const": "bus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "cableway"
+                    },
+                    {
+                      "type": "string",
+                      "const": "coach"
+                    },
+                    {
+                      "type": "string",
+                      "const": "funicular"
+                    },
+                    {
+                      "type": "string",
+                      "const": "lift"
+                    },
+                    {
+                      "type": "string",
+                      "const": "metro"
+                    },
+                    {
+                      "type": "string",
+                      "const": "monorail"
+                    },
+                    {
+                      "type": "string",
+                      "const": "rail"
+                    },
+                    {
+                      "type": "string",
+                      "const": "taxi"
+                    },
+                    {
+                      "type": "string",
+                      "const": "tram"
+                    },
+                    {
+                      "type": "string",
+                      "const": "trolleybus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "unknown"
+                    },
+                    {
+                      "type": "string",
+                      "const": "water"
+                    }
+                  ]
+                },
+                "subMode": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "const": "escooter"
+                    },
+                    {
+                      "type": "string",
+                      "const": "SchengenAreaFlight"
+                    },
+                    {
+                      "type": "string",
+                      "const": "airportBoatLink"
+                    },
+                    {
+                      "type": "string",
+                      "const": "airportLinkBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "airportLinkRail"
+                    },
+                    {
+                      "type": "string",
+                      "const": "airshipService"
+                    },
+                    {
+                      "type": "string",
+                      "const": "allFunicularServices"
+                    },
+                    {
+                      "type": "string",
+                      "const": "allHireVehicles"
+                    },
+                    {
+                      "type": "string",
+                      "const": "allTaxiServices"
+                    },
+                    {
+                      "type": "string",
+                      "const": "bikeTaxi"
+                    },
+                    {
+                      "type": "string",
+                      "const": "blackCab"
+                    },
+                    {
+                      "type": "string",
+                      "const": "cableCar"
+                    },
+                    {
+                      "type": "string",
+                      "const": "cableFerry"
+                    },
+                    {
+                      "type": "string",
+                      "const": "canalBarge"
+                    },
+                    {
+                      "type": "string",
+                      "const": "carTransportRailService"
+                    },
+                    {
+                      "type": "string",
+                      "const": "chairLift"
+                    },
+                    {
+                      "type": "string",
+                      "const": "charterTaxi"
+                    },
+                    {
+                      "type": "string",
+                      "const": "cityTram"
+                    },
+                    {
+                      "type": "string",
+                      "const": "communalTaxi"
+                    },
+                    {
+                      "type": "string",
+                      "const": "commuterCoach"
+                    },
+                    {
+                      "type": "string",
+                      "const": "crossCountryRail"
+                    },
+                    {
+                      "type": "string",
+                      "const": "dedicatedLaneBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "demandAndResponseBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "domesticCharterFlight"
+                    },
+                    {
+                      "type": "string",
+                      "const": "domesticFlight"
+                    },
+                    {
+                      "type": "string",
+                      "const": "domesticScheduledFlight"
+                    },
+                    {
+                      "type": "string",
+                      "const": "dragLift"
+                    },
+                    {
+                      "type": "string",
+                      "const": "expressBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "funicular"
+                    },
+                    {
+                      "type": "string",
+                      "const": "helicopterService"
+                    },
+                    {
+                      "type": "string",
+                      "const": "highFrequencyBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "highSpeedPassengerService"
+                    },
+                    {
+                      "type": "string",
+                      "const": "highSpeedRail"
+                    },
+                    {
+                      "type": "string",
+                      "const": "highSpeedVehicleService"
+                    },
+                    {
+                      "type": "string",
+                      "const": "hireCar"
+                    },
+                    {
+                      "type": "string",
+                      "const": "hireCycle"
+                    },
+                    {
+                      "type": "string",
+                      "const": "hireMotorbike"
+                    },
+                    {
+                      "type": "string",
+                      "const": "hireVan"
+                    },
+                    {
+                      "type": "string",
+                      "const": "intercontinentalCharterFlight"
+                    },
+                    {
+                      "type": "string",
+                      "const": "intercontinentalFlight"
+                    },
+                    {
+                      "type": "string",
+                      "const": "international"
+                    },
+                    {
+                      "type": "string",
+                      "const": "internationalCarFerry"
+                    },
+                    {
+                      "type": "string",
+                      "const": "internationalCharterFlight"
+                    },
+                    {
+                      "type": "string",
+                      "const": "internationalCoach"
+                    },
+                    {
+                      "type": "string",
+                      "const": "internationalFlight"
+                    },
+                    {
+                      "type": "string",
+                      "const": "internationalPassengerFerry"
+                    },
+                    {
+                      "type": "string",
+                      "const": "interregionalRail"
+                    },
+                    {
+                      "type": "string",
+                      "const": "lift"
+                    },
+                    {
+                      "type": "string",
+                      "const": "local"
+                    },
+                    {
+                      "type": "string",
+                      "const": "localBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "localCarFerry"
+                    },
+                    {
+                      "type": "string",
+                      "const": "localPassengerFerry"
+                    },
+                    {
+                      "type": "string",
+                      "const": "localTram"
+                    },
+                    {
+                      "type": "string",
+                      "const": "longDistance"
+                    },
+                    {
+                      "type": "string",
+                      "const": "metro"
+                    },
+                    {
+                      "type": "string",
+                      "const": "miniCab"
+                    },
+                    {
+                      "type": "string",
+                      "const": "mobilityBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "mobilityBusForRegisteredDisabled"
+                    },
+                    {
+                      "type": "string",
+                      "const": "nationalCarFerry"
+                    },
+                    {
+                      "type": "string",
+                      "const": "nationalCoach"
+                    },
+                    {
+                      "type": "string",
+                      "const": "nationalPassengerFerry"
+                    },
+                    {
+                      "type": "string",
+                      "const": "nightBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "nightRail"
+                    },
+                    {
+                      "type": "string",
+                      "const": "postBoat"
+                    },
+                    {
+                      "type": "string",
+                      "const": "postBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "rackAndPinionRailway"
+                    },
+                    {
+                      "type": "string",
+                      "const": "railReplacementBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "railShuttle"
+                    },
+                    {
+                      "type": "string",
+                      "const": "railTaxi"
+                    },
+                    {
+                      "type": "string",
+                      "const": "regionalBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "regionalCarFerry"
+                    },
+                    {
+                      "type": "string",
+                      "const": "regionalCoach"
+                    },
+                    {
+                      "type": "string",
+                      "const": "regionalPassengerFerry"
+                    },
+                    {
+                      "type": "string",
+                      "const": "regionalRail"
+                    },
+                    {
+                      "type": "string",
+                      "const": "regionalTram"
+                    },
+                    {
+                      "type": "string",
+                      "const": "replacementRailService"
+                    },
+                    {
+                      "type": "string",
+                      "const": "riverBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "roadFerryLink"
+                    },
+                    {
+                      "type": "string",
+                      "const": "roundTripCharterFlight"
+                    },
+                    {
+                      "type": "string",
+                      "const": "scheduledFerry"
+                    },
+                    {
+                      "type": "string",
+                      "const": "schoolAndPublicServiceBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "schoolBoat"
+                    },
+                    {
+                      "type": "string",
+                      "const": "schoolBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "schoolCoach"
+                    },
+                    {
+                      "type": "string",
+                      "const": "shortHaulInternationalFlight"
+                    },
+                    {
+                      "type": "string",
+                      "const": "shuttleBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "shuttleCoach"
+                    },
+                    {
+                      "type": "string",
+                      "const": "shuttleFerryService"
+                    },
+                    {
+                      "type": "string",
+                      "const": "shuttleFlight"
+                    },
+                    {
+                      "type": "string",
+                      "const": "shuttleTram"
+                    },
+                    {
+                      "type": "string",
+                      "const": "sightseeingBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "sightseeingCoach"
+                    },
+                    {
+                      "type": "string",
+                      "const": "sightseeingFlight"
+                    },
+                    {
+                      "type": "string",
+                      "const": "sightseeingService"
+                    },
+                    {
+                      "type": "string",
+                      "const": "sightseeingTram"
+                    },
+                    {
+                      "type": "string",
+                      "const": "sleeperRailService"
+                    },
+                    {
+                      "type": "string",
+                      "const": "specialCoach"
+                    },
+                    {
+                      "type": "string",
+                      "const": "specialNeedsBus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "specialTrain"
+                    },
+                    {
+                      "type": "string",
+                      "const": "streetCableCar"
+                    },
+                    {
+                      "type": "string",
+                      "const": "suburbanRailway"
+                    },
+                    {
+                      "type": "string",
+                      "const": "telecabin"
+                    },
+                    {
+                      "type": "string",
+                      "const": "telecabinLink"
+                    },
+                    {
+                      "type": "string",
+                      "const": "touristCoach"
+                    },
+                    {
+                      "type": "string",
+                      "const": "touristRailway"
+                    },
+                    {
+                      "type": "string",
+                      "const": "trainFerry"
+                    },
+                    {
+                      "type": "string",
+                      "const": "trainTram"
+                    },
+                    {
+                      "type": "string",
+                      "const": "tube"
+                    },
+                    {
+                      "type": "string",
+                      "const": "undefined"
+                    },
+                    {
+                      "type": "string",
+                      "const": "undefinedFunicular"
+                    },
+                    {
+                      "type": "string",
+                      "const": "unknown"
+                    },
+                    {
+                      "type": "string",
+                      "const": "urbanRailway"
+                    },
+                    {
+                      "type": "string",
+                      "const": "waterTaxi"
+                    }
+                  ]
+                }
+              },
+              "required": ["mode"],
+              "additionalProperties": false
+            }
+          },
+          "types": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "heading": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "lang": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["lang", "value"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "language": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
+          }
+        },
+        "required": ["transportModes", "types"],
+        "additionalProperties": false
+      }
     }
   },
-  "$schema": "http://json-schema.org/draft-07/schema#"
+  "required": ["fareProductTypeConfigs"],
+  "additionalProperties": false
 }

--- a/schema-definitions/harborConnectionOverrides.json
+++ b/schema-definitions/harborConnectionOverrides.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "properties": {
     "overrides": {
@@ -22,6 +23,5 @@
     }
   },
   "required": ["overrides"],
-  "additionalProperties": false,
-  "$schema": "http://json-schema.org/draft-07/schema#"
+  "additionalProperties": false
 }

--- a/schema-definitions/mobility.json
+++ b/schema-definitions/mobility.json
@@ -1,53 +1,208 @@
 {
-  "$ref": "#/definitions/MobilityOperator",
-  "definitions": {
-    "FormFactor": {
-      "type": "string",
-      "enum": ["SCOOTER", "BICYCLE", "CAR"]
-    },
-    "OperatorBenefitId": {
-      "type": "string",
-      "enum": ["free-unlock", "free-use", "single-unlock"]
-    },
-    "MobilityOperator": {
-      "type": "object",
-      "properties": {
-        "operators": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "minLength": 1
-              },
-              "name": {
-                "type": "string",
-                "minLength": 1
-              },
-              "showInApp": {
-                "type": "boolean",
-                "default": false
-              },
-              "formFactors": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/FormFactor"
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "MobilityOperator",
+  "type": "object",
+  "properties": {
+    "operators": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "showInApp": {
+            "default": false,
+            "type": "boolean"
+          },
+          "formFactors": {
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "const": "SCOOTER"
                 },
-                "minItems": 1
-              },
-              "benefits": {
-                "type": "array",
-                "items": {
+                {
+                  "type": "string",
+                  "const": "BICYCLE"
+                },
+                {
+                  "type": "string",
+                  "const": "CAR"
+                }
+              ]
+            }
+          },
+          "benefits": {
+            "default": [],
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "const": "free-unlock"
+                    },
+                    {
+                      "type": "string",
+                      "const": "free-use"
+                    },
+                    {
+                      "type": "string",
+                      "const": "single-unlock"
+                    }
+                  ]
+                },
+                "imageWhenActive": {
+                  "type": "string"
+                },
+                "headingWhenActive": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "lang": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["lang", "value"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "language": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
+                "descriptionWhenActive": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "lang": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["lang", "value"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "language": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
+                "imageWhenNotActive": {
+                  "type": "string"
+                },
+                "headingWhenNotActive": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "lang": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["lang", "value"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "language": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
+                "descriptionWhenNotActive": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "lang": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["lang", "value"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "language": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
+                "callToAction": {
                   "type": "object",
                   "properties": {
-                    "id": {
-                      "$ref": "#/definitions/OperatorBenefitId"
-                    },
-                    "imageWhenActive": {
+                    "url": {
                       "type": "string"
                     },
-                    "headingWhenActive": {
+                    "name": {
                       "type": "array",
                       "items": {
                         "anyOf": [
@@ -78,299 +233,588 @@
                           }
                         ]
                       }
-                    },
-                    "descriptionWhenActive": {
-                      "$ref": "#/definitions/MobilityOperator/properties/operators/items/properties/benefits/items/properties/headingWhenActive"
-                    },
-                    "imageWhenNotActive": {
-                      "type": "string"
-                    },
-                    "headingWhenNotActive": {
-                      "$ref": "#/definitions/MobilityOperator/properties/operators/items/properties/benefits/items/properties/headingWhenActive"
-                    },
-                    "descriptionWhenNotActive": {
-                      "$ref": "#/definitions/MobilityOperator/properties/operators/items/properties/benefits/items/properties/headingWhenActive"
-                    },
-                    "callToAction": {
-                      "type": "object",
-                      "properties": {
-                        "url": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "$ref": "#/definitions/MobilityOperator/properties/operators/items/properties/benefits/items/properties/headingWhenActive"
-                        }
-                      },
-                      "required": ["url"],
-                      "additionalProperties": false
-                    },
-                    "ticketDescription": {
-                      "$ref": "#/definitions/MobilityOperator/properties/operators/items/properties/benefits/items/properties/headingWhenActive"
-                    },
-                    "formFactors": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/definitions/FormFactor"
-                      },
-                      "minItems": 1
                     }
                   },
-                  "required": [
-                    "id",
-                    "descriptionWhenActive",
-                    "descriptionWhenNotActive",
-                    "callToAction",
-                    "formFactors"
-                  ],
+                  "required": ["url"],
                   "additionalProperties": false
                 },
-                "default": []
-              },
-              "brandAssets": {
-                "type": "object",
-                "properties": {
-                  "brandLastModified": {
-                    "type": "string",
-                    "format": "date"
-                  },
-                  "brandTermsUrl": {
-                    "type": "string",
-                    "format": "uri"
-                  },
-                  "brandImageUrl": {
-                    "type": "string"
-                  },
-                  "brandImageUrlDark": {
-                    "type": "string"
-                  },
-                  "color": {
-                    "type": "string"
+                "ticketDescription": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "lang": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["lang", "value"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "language": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    ]
                   }
                 },
-                "required": ["brandLastModified", "brandImageUrl"],
-                "additionalProperties": false,
-                "description": "modeled 1-1 like brandAssets in EnTur mobility API"
-              },
-              "isDeepIntegrationEnabled": {
-                "type": "boolean",
-                "default": false
-              },
-              "ageLimit": {
-                "type": "integer",
-                "exclusiveMinimum": 0
-              },
-              "appUrl": {
-                "type": "object",
-                "properties": {
-                  "ios": {
-                    "type": "string",
-                    "format": "uri"
-                  },
-                  "android": {
-                    "type": "string",
-                    "format": "uri"
+                "formFactors": {
+                  "minItems": 1,
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "const": "SCOOTER"
+                      },
+                      {
+                        "type": "string",
+                        "const": "BICYCLE"
+                      },
+                      {
+                        "type": "string",
+                        "const": "CAR"
+                      }
+                    ]
                   }
-                },
-                "required": ["ios", "android"],
-                "additionalProperties": false
-              }
-            },
-            "required": ["id", "name", "formFactors"],
-            "additionalProperties": false
-          }
-        },
-        "scooterFaqs": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string"
+                }
               },
-              "title": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/MobilityOperator/properties/operators/items/properties/benefits/items/properties/headingWhenActive/items"
-                },
-                "minItems": 1
-              },
-              "description": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/MobilityOperator/properties/operators/items/properties/benefits/items/properties/headingWhenActive/items"
-                },
-                "minItems": 1
-              }
-            },
-            "required": ["id", "title", "description"],
-            "additionalProperties": false
-          }
-        },
-        "scooterConsentLines": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "minLength": 1
-              },
-              "illustration": {
-                "type": "string"
-              },
-              "description": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/MobilityOperator/properties/operators/items/properties/benefits/items/properties/headingWhenActive/items"
-                },
-                "minItems": 1
-              }
-            },
-            "required": ["id", "description"],
-            "additionalProperties": false
-          }
-        },
-        "benefitIdsRequiringValueCode": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/OperatorBenefitId"
-          }
-        },
-        "bonusProducts": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "minLength": 1
-              },
-              "isActive": {
-                "type": "boolean"
-              },
-              "operatorId": {
-                "$ref": "#/definitions/MobilityOperator/properties/operators/items/properties/id"
-              },
-              "formFactors": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/FormFactor"
-                },
-                "minItems": 1
-              },
-              "price": {
-                "type": "object",
-                "properties": {
-                  "amount": {
-                    "type": "integer",
-                    "exclusiveMinimum": 0
-                  },
-                  "currencyCode": {
-                    "type": "string",
-                    "const": "ATB_BONUS_POINT"
-                  }
-                },
-                "required": ["amount", "currencyCode"],
-                "additionalProperties": false
-              },
-              "paymentDescription": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/MobilityOperator/properties/operators/items/properties/benefits/items/properties/headingWhenActive/items"
-                },
-                "minItems": 1
-              },
-              "productDescription": {
-                "type": "object",
-                "properties": {
-                  "title": {
-                    "$ref": "#/definitions/MobilityOperator/properties/scooterFaqs/items/properties/title"
-                  },
-                  "description": {
-                    "$ref": "#/definitions/MobilityOperator/properties/scooterFaqs/items/properties/description"
-                  }
-                },
-                "required": ["title", "description"],
-                "additionalProperties": false
-              }
-            },
-            "required": [
-              "id",
-              "isActive",
-              "operatorId",
-              "formFactors",
-              "price",
-              "paymentDescription",
-              "productDescription"
-            ],
-            "additionalProperties": false
-          }
-        },
-        "bonusTexts": {
-          "type": "object",
-          "properties": {
-            "howBonusWorks": {
-              "$ref": "#/definitions/MobilityOperator/properties/bonusProducts/items/properties/productDescription"
+              "required": [
+                "id",
+                "descriptionWhenActive",
+                "descriptionWhenNotActive",
+                "callToAction",
+                "formFactors"
+              ],
+              "additionalProperties": false
             }
           },
-          "required": ["howBonusWorks"],
-          "additionalProperties": false
-        },
-        "bonusSources": {
-          "type": "array",
-          "items": {
+          "brandAssets": {
+            "description": "modeled 1-1 like brandAssets in EnTur mobility API",
             "type": "object",
             "properties": {
-              "id": {
+              "brandLastModified": {
+                "type": "string",
+                "format": "date",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))$"
+              },
+              "brandTermsUrl": {
+                "type": "string",
+                "format": "uri"
+              },
+              "brandImageUrl": {
                 "type": "string"
               },
-              "preassignedFareProductId": {
+              "brandImageUrlDark": {
                 "type": "string"
               },
-              "userProfileIds": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
+              "color": {
+                "type": "string"
+              }
+            },
+            "required": ["brandLastModified", "brandImageUrl"],
+            "additionalProperties": false
+          },
+          "isDeepIntegrationEnabled": {
+            "default": false,
+            "type": "boolean"
+          },
+          "ageLimit": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          },
+          "appUrl": {
+            "type": "object",
+            "properties": {
+              "ios": {
+                "type": "string",
+                "format": "uri"
               },
-              "fareZones": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "amountByEnrollment": {
-                "type": "array",
-                "items": {
+              "android": {
+                "type": "string",
+                "format": "uri"
+              }
+            },
+            "required": ["ios", "android"],
+            "additionalProperties": false
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "showInApp",
+          "formFactors",
+          "benefits",
+          "isDeepIntegrationEnabled"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "scooterFaqs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
                   "type": "object",
                   "properties": {
-                    "enrollmentId": {
+                    "lang": {
                       "type": "string"
                     },
-                    "amount": {
-                      "type": "integer",
-                      "exclusiveMinimum": 0
+                    "value": {
+                      "type": "string"
                     }
                   },
-                  "required": ["amount"],
+                  "required": ["lang", "value"],
                   "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "language": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
+          },
+          "description": {
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "lang": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["lang", "value"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "language": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
+          }
+        },
+        "required": ["id", "title", "description"],
+        "additionalProperties": false
+      }
+    },
+    "scooterConsentLines": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "illustration": {
+            "type": "string"
+          },
+          "description": {
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "lang": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["lang", "value"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "language": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
+          }
+        },
+        "required": ["id", "description"],
+        "additionalProperties": false
+      }
+    },
+    "benefitIdsRequiringValueCode": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "string",
+            "const": "free-unlock"
+          },
+          {
+            "type": "string",
+            "const": "free-use"
+          },
+          {
+            "type": "string",
+            "const": "single-unlock"
+          }
+        ]
+      }
+    },
+    "bonusProducts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "operatorId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "formFactors": {
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "const": "SCOOTER"
+                },
+                {
+                  "type": "string",
+                  "const": "BICYCLE"
+                },
+                {
+                  "type": "string",
+                  "const": "CAR"
+                }
+              ]
+            }
+          },
+          "price": {
+            "type": "object",
+            "properties": {
+              "amount": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "currencyCode": {
+                "type": "string",
+                "const": "ATB_BONUS_POINT"
+              }
+            },
+            "required": ["amount", "currencyCode"],
+            "additionalProperties": false
+          },
+          "paymentDescription": {
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "lang": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["lang", "value"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "language": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
+          },
+          "productDescription": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "minItems": 1,
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "lang": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["lang", "value"],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "language": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              },
+              "description": {
+                "minItems": 1,
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "lang": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["lang", "value"],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "language": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ]
                 }
               }
             },
-            "required": [
-              "id",
-              "preassignedFareProductId",
-              "userProfileIds",
-              "fareZones",
-              "amountByEnrollment"
-            ],
+            "required": ["title", "description"],
             "additionalProperties": false
           }
+        },
+        "required": [
+          "id",
+          "isActive",
+          "operatorId",
+          "formFactors",
+          "price",
+          "paymentDescription",
+          "productDescription"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "bonusTexts": {
+      "type": "object",
+      "properties": {
+        "howBonusWorks": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "minItems": 1,
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "lang": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["lang", "value"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "language": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            },
+            "description": {
+              "minItems": 1,
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "lang": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["lang", "value"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "language": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            }
+          },
+          "required": ["title", "description"],
+          "additionalProperties": false
         }
       },
-      "required": ["operators"],
+      "required": ["howBonusWorks"],
       "additionalProperties": false
+    },
+    "bonusSources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "preassignedFareProductId": {
+            "type": "string"
+          },
+          "userProfileIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "fareZones": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "amountByEnrollment": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "enrollmentId": {
+                  "type": "string"
+                },
+                "amount": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                }
+              },
+              "required": ["amount"],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "id",
+          "preassignedFareProductId",
+          "userProfileIds",
+          "fareZones",
+          "amountByEnrollment"
+        ],
+        "additionalProperties": false
+      }
     }
   },
-  "$schema": "http://json-schema.org/draft-07/schema#"
+  "required": ["operators"],
+  "additionalProperties": false
 }

--- a/schema-definitions/notificationConfig.json
+++ b/schema-definitions/notificationConfig.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "properties": {
     "groups": {
@@ -51,7 +52,36 @@
             }
           },
           "toggleTitle": {
-            "$ref": "#/properties/groups/items/properties/toggleDescription"
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "lang": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["lang", "value"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "language": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
           }
         },
         "required": [
@@ -82,6 +112,5 @@
     }
   },
   "required": ["groups", "modes"],
-  "additionalProperties": false,
-  "$schema": "http://json-schema.org/draft-07/schema#"
+  "additionalProperties": false
 }

--- a/schema-definitions/other.json
+++ b/schema-definitions/other.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "properties": {
     "vatPercent": {
@@ -18,134 +19,472 @@
       "type": "number"
     },
     "travelcardNumberLength": {
-      "type": "number",
-      "default": 16
+      "default": 16,
+      "type": "number"
     },
     "modesWeSellTicketsFor": {
       "type": "array",
       "items": {
-        "type": "string",
-        "enum": [
-          "escooter",
-          "SchengenAreaFlight",
-          "airportBoatLink",
-          "airportLinkBus",
-          "airportLinkRail",
-          "airshipService",
-          "allFunicularServices",
-          "allHireVehicles",
-          "allTaxiServices",
-          "bikeTaxi",
-          "blackCab",
-          "cableCar",
-          "cableFerry",
-          "canalBarge",
-          "carTransportRailService",
-          "chairLift",
-          "charterTaxi",
-          "cityTram",
-          "communalTaxi",
-          "commuterCoach",
-          "crossCountryRail",
-          "dedicatedLaneBus",
-          "demandAndResponseBus",
-          "domesticCharterFlight",
-          "domesticFlight",
-          "domesticScheduledFlight",
-          "dragLift",
-          "expressBus",
-          "funicular",
-          "helicopterService",
-          "highFrequencyBus",
-          "highSpeedPassengerService",
-          "highSpeedRail",
-          "highSpeedVehicleService",
-          "hireCar",
-          "hireCycle",
-          "hireMotorbike",
-          "hireVan",
-          "intercontinentalCharterFlight",
-          "intercontinentalFlight",
-          "international",
-          "internationalCarFerry",
-          "internationalCharterFlight",
-          "internationalCoach",
-          "internationalFlight",
-          "internationalPassengerFerry",
-          "interregionalRail",
-          "lift",
-          "local",
-          "localBus",
-          "localCarFerry",
-          "localPassengerFerry",
-          "localTram",
-          "longDistance",
-          "metro",
-          "miniCab",
-          "mobilityBus",
-          "mobilityBusForRegisteredDisabled",
-          "nationalCarFerry",
-          "nationalCoach",
-          "nationalPassengerFerry",
-          "nightBus",
-          "nightRail",
-          "postBoat",
-          "postBus",
-          "rackAndPinionRailway",
-          "railReplacementBus",
-          "railShuttle",
-          "railTaxi",
-          "regionalBus",
-          "regionalCarFerry",
-          "regionalCoach",
-          "regionalPassengerFerry",
-          "regionalRail",
-          "regionalTram",
-          "replacementRailService",
-          "riverBus",
-          "roadFerryLink",
-          "roundTripCharterFlight",
-          "scheduledFerry",
-          "schoolAndPublicServiceBus",
-          "schoolBoat",
-          "schoolBus",
-          "schoolCoach",
-          "shortHaulInternationalFlight",
-          "shuttleBus",
-          "shuttleCoach",
-          "shuttleFerryService",
-          "shuttleFlight",
-          "shuttleTram",
-          "sightseeingBus",
-          "sightseeingCoach",
-          "sightseeingFlight",
-          "sightseeingService",
-          "sightseeingTram",
-          "sleeperRailService",
-          "specialCoach",
-          "specialNeedsBus",
-          "specialTrain",
-          "streetCableCar",
-          "suburbanRailway",
-          "telecabin",
-          "telecabinLink",
-          "touristCoach",
-          "touristRailway",
-          "trainFerry",
-          "trainTram",
-          "tube",
-          "undefined",
-          "undefinedFunicular",
-          "unknown",
-          "urbanRailway",
-          "waterTaxi"
+        "anyOf": [
+          {
+            "type": "string",
+            "const": "escooter"
+          },
+          {
+            "type": "string",
+            "const": "SchengenAreaFlight"
+          },
+          {
+            "type": "string",
+            "const": "airportBoatLink"
+          },
+          {
+            "type": "string",
+            "const": "airportLinkBus"
+          },
+          {
+            "type": "string",
+            "const": "airportLinkRail"
+          },
+          {
+            "type": "string",
+            "const": "airshipService"
+          },
+          {
+            "type": "string",
+            "const": "allFunicularServices"
+          },
+          {
+            "type": "string",
+            "const": "allHireVehicles"
+          },
+          {
+            "type": "string",
+            "const": "allTaxiServices"
+          },
+          {
+            "type": "string",
+            "const": "bikeTaxi"
+          },
+          {
+            "type": "string",
+            "const": "blackCab"
+          },
+          {
+            "type": "string",
+            "const": "cableCar"
+          },
+          {
+            "type": "string",
+            "const": "cableFerry"
+          },
+          {
+            "type": "string",
+            "const": "canalBarge"
+          },
+          {
+            "type": "string",
+            "const": "carTransportRailService"
+          },
+          {
+            "type": "string",
+            "const": "chairLift"
+          },
+          {
+            "type": "string",
+            "const": "charterTaxi"
+          },
+          {
+            "type": "string",
+            "const": "cityTram"
+          },
+          {
+            "type": "string",
+            "const": "communalTaxi"
+          },
+          {
+            "type": "string",
+            "const": "commuterCoach"
+          },
+          {
+            "type": "string",
+            "const": "crossCountryRail"
+          },
+          {
+            "type": "string",
+            "const": "dedicatedLaneBus"
+          },
+          {
+            "type": "string",
+            "const": "demandAndResponseBus"
+          },
+          {
+            "type": "string",
+            "const": "domesticCharterFlight"
+          },
+          {
+            "type": "string",
+            "const": "domesticFlight"
+          },
+          {
+            "type": "string",
+            "const": "domesticScheduledFlight"
+          },
+          {
+            "type": "string",
+            "const": "dragLift"
+          },
+          {
+            "type": "string",
+            "const": "expressBus"
+          },
+          {
+            "type": "string",
+            "const": "funicular"
+          },
+          {
+            "type": "string",
+            "const": "helicopterService"
+          },
+          {
+            "type": "string",
+            "const": "highFrequencyBus"
+          },
+          {
+            "type": "string",
+            "const": "highSpeedPassengerService"
+          },
+          {
+            "type": "string",
+            "const": "highSpeedRail"
+          },
+          {
+            "type": "string",
+            "const": "highSpeedVehicleService"
+          },
+          {
+            "type": "string",
+            "const": "hireCar"
+          },
+          {
+            "type": "string",
+            "const": "hireCycle"
+          },
+          {
+            "type": "string",
+            "const": "hireMotorbike"
+          },
+          {
+            "type": "string",
+            "const": "hireVan"
+          },
+          {
+            "type": "string",
+            "const": "intercontinentalCharterFlight"
+          },
+          {
+            "type": "string",
+            "const": "intercontinentalFlight"
+          },
+          {
+            "type": "string",
+            "const": "international"
+          },
+          {
+            "type": "string",
+            "const": "internationalCarFerry"
+          },
+          {
+            "type": "string",
+            "const": "internationalCharterFlight"
+          },
+          {
+            "type": "string",
+            "const": "internationalCoach"
+          },
+          {
+            "type": "string",
+            "const": "internationalFlight"
+          },
+          {
+            "type": "string",
+            "const": "internationalPassengerFerry"
+          },
+          {
+            "type": "string",
+            "const": "interregionalRail"
+          },
+          {
+            "type": "string",
+            "const": "lift"
+          },
+          {
+            "type": "string",
+            "const": "local"
+          },
+          {
+            "type": "string",
+            "const": "localBus"
+          },
+          {
+            "type": "string",
+            "const": "localCarFerry"
+          },
+          {
+            "type": "string",
+            "const": "localPassengerFerry"
+          },
+          {
+            "type": "string",
+            "const": "localTram"
+          },
+          {
+            "type": "string",
+            "const": "longDistance"
+          },
+          {
+            "type": "string",
+            "const": "metro"
+          },
+          {
+            "type": "string",
+            "const": "miniCab"
+          },
+          {
+            "type": "string",
+            "const": "mobilityBus"
+          },
+          {
+            "type": "string",
+            "const": "mobilityBusForRegisteredDisabled"
+          },
+          {
+            "type": "string",
+            "const": "nationalCarFerry"
+          },
+          {
+            "type": "string",
+            "const": "nationalCoach"
+          },
+          {
+            "type": "string",
+            "const": "nationalPassengerFerry"
+          },
+          {
+            "type": "string",
+            "const": "nightBus"
+          },
+          {
+            "type": "string",
+            "const": "nightRail"
+          },
+          {
+            "type": "string",
+            "const": "postBoat"
+          },
+          {
+            "type": "string",
+            "const": "postBus"
+          },
+          {
+            "type": "string",
+            "const": "rackAndPinionRailway"
+          },
+          {
+            "type": "string",
+            "const": "railReplacementBus"
+          },
+          {
+            "type": "string",
+            "const": "railShuttle"
+          },
+          {
+            "type": "string",
+            "const": "railTaxi"
+          },
+          {
+            "type": "string",
+            "const": "regionalBus"
+          },
+          {
+            "type": "string",
+            "const": "regionalCarFerry"
+          },
+          {
+            "type": "string",
+            "const": "regionalCoach"
+          },
+          {
+            "type": "string",
+            "const": "regionalPassengerFerry"
+          },
+          {
+            "type": "string",
+            "const": "regionalRail"
+          },
+          {
+            "type": "string",
+            "const": "regionalTram"
+          },
+          {
+            "type": "string",
+            "const": "replacementRailService"
+          },
+          {
+            "type": "string",
+            "const": "riverBus"
+          },
+          {
+            "type": "string",
+            "const": "roadFerryLink"
+          },
+          {
+            "type": "string",
+            "const": "roundTripCharterFlight"
+          },
+          {
+            "type": "string",
+            "const": "scheduledFerry"
+          },
+          {
+            "type": "string",
+            "const": "schoolAndPublicServiceBus"
+          },
+          {
+            "type": "string",
+            "const": "schoolBoat"
+          },
+          {
+            "type": "string",
+            "const": "schoolBus"
+          },
+          {
+            "type": "string",
+            "const": "schoolCoach"
+          },
+          {
+            "type": "string",
+            "const": "shortHaulInternationalFlight"
+          },
+          {
+            "type": "string",
+            "const": "shuttleBus"
+          },
+          {
+            "type": "string",
+            "const": "shuttleCoach"
+          },
+          {
+            "type": "string",
+            "const": "shuttleFerryService"
+          },
+          {
+            "type": "string",
+            "const": "shuttleFlight"
+          },
+          {
+            "type": "string",
+            "const": "shuttleTram"
+          },
+          {
+            "type": "string",
+            "const": "sightseeingBus"
+          },
+          {
+            "type": "string",
+            "const": "sightseeingCoach"
+          },
+          {
+            "type": "string",
+            "const": "sightseeingFlight"
+          },
+          {
+            "type": "string",
+            "const": "sightseeingService"
+          },
+          {
+            "type": "string",
+            "const": "sightseeingTram"
+          },
+          {
+            "type": "string",
+            "const": "sleeperRailService"
+          },
+          {
+            "type": "string",
+            "const": "specialCoach"
+          },
+          {
+            "type": "string",
+            "const": "specialNeedsBus"
+          },
+          {
+            "type": "string",
+            "const": "specialTrain"
+          },
+          {
+            "type": "string",
+            "const": "streetCableCar"
+          },
+          {
+            "type": "string",
+            "const": "suburbanRailway"
+          },
+          {
+            "type": "string",
+            "const": "telecabin"
+          },
+          {
+            "type": "string",
+            "const": "telecabinLink"
+          },
+          {
+            "type": "string",
+            "const": "touristCoach"
+          },
+          {
+            "type": "string",
+            "const": "touristRailway"
+          },
+          {
+            "type": "string",
+            "const": "trainFerry"
+          },
+          {
+            "type": "string",
+            "const": "trainTram"
+          },
+          {
+            "type": "string",
+            "const": "tube"
+          },
+          {
+            "type": "string",
+            "const": "undefined"
+          },
+          {
+            "type": "string",
+            "const": "undefinedFunicular"
+          },
+          {
+            "type": "string",
+            "const": "unknown"
+          },
+          {
+            "type": "string",
+            "const": "urbanRailway"
+          },
+          {
+            "type": "string",
+            "const": "waterTaxi"
+          }
         ]
       }
     },
     "nextMorningUtcTimestamp": {
+      "default": "04:00",
       "type": "string",
-      "pattern": "^\\d{2}:\\d{2}$",
-      "default": "04:00"
+      "pattern": "^\\d{2}:\\d{2}$"
     },
     "defaultTariffZone": {
       "type": "string"
@@ -170,14 +509,18 @@
         "web": {
           "type": "array",
           "items": {
-            "$ref": "#/properties/disabledLoginMethods/properties/app/items"
+            "type": "string",
+            "enum": ["otp", "email", "vipps"]
           }
         }
       },
       "additionalProperties": false
     }
   },
-  "required": ["vatPercent"],
-  "additionalProperties": false,
-  "$schema": "http://json-schema.org/draft-07/schema#"
+  "required": [
+    "vatPercent",
+    "travelcardNumberLength",
+    "nextMorningUtcTimestamp"
+  ],
+  "additionalProperties": false
 }

--- a/schema-definitions/paymentTypes.json
+++ b/schema-definitions/paymentTypes.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "properties": {
     "app": {
@@ -11,10 +12,10 @@
     "web": {
       "type": "array",
       "items": {
-        "$ref": "#/properties/app/items"
+        "type": "string",
+        "enum": ["vipps", "visa", "mastercard", "amex"]
       }
     }
   },
-  "additionalProperties": false,
-  "$schema": "http://json-schema.org/draft-07/schema#"
+  "additionalProperties": false
 }

--- a/schema-definitions/referenceData.json
+++ b/schema-definitions/referenceData.json
@@ -34,8 +34,7 @@
                     "type": "string"
                   }
                 },
-                "required": ["lang", "value"],
-                "additionalProperties": false
+                "required": ["lang", "value"]
               },
               {
                 "type": "object",
@@ -46,8 +45,7 @@
                   "value": {
                     "type": "string"
                   }
-                },
-                "additionalProperties": false
+                }
               }
             ]
           },
@@ -61,240 +59,341 @@
                 }
               },
               "appVersionMin": {
-                "type": "string"
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               },
               "appVersionMax": {
-                "type": "string"
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               },
               "fareZoneRefs": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
+                "anyOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               },
               "tariffZoneRefs": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
+                "anyOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               }
             },
-            "required": ["userProfileRefs"],
-            "additionalProperties": false
+            "required": ["userProfileRefs"]
           },
           "durationDays": {
-            "type": "number"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "isApplicableOnSingleZoneOnly": {
-            "type": "boolean"
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "isBookingEnabled": {
-            "type": "boolean"
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "isEnabledForTripSearchOffer": {
-            "type": "boolean"
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "isDefault": {
-            "type": "boolean"
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "alternativeNames": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "lang": {
-                      "type": "string"
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "lang": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["lang", "value"]
                     },
-                    "value": {
-                      "type": "string"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "language": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
-                  },
-                  "required": ["lang", "value"],
-                  "additionalProperties": false
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "language": {
-                      "type": "string"
-                    },
-                    "value": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false
+                  ]
                 }
-              ]
-            }
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "zoneSelectionMode": {
             "anyOf": [
               {
-                "type": "string",
-                "const": "none"
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "const": "none"
+                  },
+                  {
+                    "type": "string",
+                    "const": "single"
+                  },
+                  {
+                    "type": "string",
+                    "const": "single-stop"
+                  },
+                  {
+                    "type": "string",
+                    "const": "single-zone"
+                  },
+                  {
+                    "type": "string",
+                    "const": "multiple"
+                  },
+                  {
+                    "type": "string",
+                    "const": "multiple-stop"
+                  },
+                  {
+                    "type": "string",
+                    "const": "multiple-zone"
+                  },
+                  {
+                    "type": "string",
+                    "const": "multiple-stop-harbor"
+                  }
+                ]
               },
               {
-                "type": "string",
-                "const": "single"
-              },
-              {
-                "type": "string",
-                "const": "single-stop"
-              },
-              {
-                "type": "string",
-                "const": "single-zone"
-              },
-              {
-                "type": "string",
-                "const": "multiple"
-              },
-              {
-                "type": "string",
-                "const": "multiple-stop"
-              },
-              {
-                "type": "string",
-                "const": "multiple-zone"
-              },
-              {
-                "type": "string",
-                "const": "multiple-stop-harbor"
+                "type": "null"
               }
             ]
           },
           "description": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "lang": {
-                      "type": "string"
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "lang": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["lang", "value"]
                     },
-                    "value": {
-                      "type": "string"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "language": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
-                  },
-                  "required": ["lang", "value"],
-                  "additionalProperties": false
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "language": {
-                      "type": "string"
-                    },
-                    "value": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false
+                  ]
                 }
-              ]
-            }
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "productDescription": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "lang": {
-                      "type": "string"
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "lang": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["lang", "value"]
                     },
-                    "value": {
-                      "type": "string"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "language": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
-                  },
-                  "required": ["lang", "value"],
-                  "additionalProperties": false
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "language": {
-                      "type": "string"
-                    },
-                    "value": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false
+                  ]
                 }
-              ]
-            }
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "productAliasId": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "productAlias": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "lang": {
-                      "type": "string"
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "lang": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["lang", "value"]
                     },
-                    "value": {
-                      "type": "string"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "language": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
-                  },
-                  "required": ["lang", "value"],
-                  "additionalProperties": false
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "language": {
-                      "type": "string"
-                    },
-                    "value": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false
+                  ]
                 }
-              ]
-            }
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "warningMessage": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "lang": {
-                      "type": "string"
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "lang": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["lang", "value"]
                     },
-                    "value": {
-                      "type": "string"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "language": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
-                  },
-                  "required": ["lang", "value"],
-                  "additionalProperties": false
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "language": {
-                      "type": "string"
-                    },
-                    "value": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false
+                  ]
                 }
-              ]
-            }
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": [
@@ -304,8 +403,7 @@
           "distributionChannel",
           "name",
           "limitations"
-        ],
-        "additionalProperties": false
+        ]
       }
     },
     "fareZones": {
@@ -328,8 +426,7 @@
                     "type": "string"
                   }
                 },
-                "required": ["lang", "value"],
-                "additionalProperties": false
+                "required": ["lang", "value"]
               },
               {
                 "type": "object",
@@ -340,8 +437,7 @@
                   "value": {
                     "type": "string"
                   }
-                },
-                "additionalProperties": false
+                }
               }
             ]
           },
@@ -370,8 +466,7 @@
                 }
               }
             },
-            "required": ["type", "coordinates"],
-            "additionalProperties": false
+            "required": ["type", "coordinates"]
           },
           "description": {
             "type": "array",
@@ -387,8 +482,7 @@
                       "type": "string"
                     }
                   },
-                  "required": ["lang", "value"],
-                  "additionalProperties": false
+                  "required": ["lang", "value"]
                 },
                 {
                   "type": "object",
@@ -399,8 +493,7 @@
                     "value": {
                       "type": "string"
                     }
-                  },
-                  "additionalProperties": false
+                  }
                 }
               ]
             }
@@ -409,8 +502,7 @@
             "type": "boolean"
           }
         },
-        "required": ["id", "name", "version", "geometry"],
-        "additionalProperties": false
+        "required": ["id", "name", "version", "geometry"]
       }
     },
     "userProfiles": {
@@ -442,8 +534,7 @@
                     "type": "string"
                   }
                 },
-                "required": ["lang", "value"],
-                "additionalProperties": false
+                "required": ["lang", "value"]
               },
               {
                 "type": "object",
@@ -454,8 +545,7 @@
                   "value": {
                     "type": "string"
                   }
-                },
-                "additionalProperties": false
+                }
               }
             ]
           },
@@ -473,8 +563,7 @@
                       "type": "string"
                     }
                   },
-                  "required": ["lang", "value"],
-                  "additionalProperties": false
+                  "required": ["lang", "value"]
                 },
                 {
                   "type": "object",
@@ -485,8 +574,7 @@
                     "value": {
                       "type": "string"
                     }
-                  },
-                  "additionalProperties": false
+                  }
                 }
               ]
             }
@@ -503,8 +591,7 @@
                     "type": "string"
                   }
                 },
-                "required": ["lang", "value"],
-                "additionalProperties": false
+                "required": ["lang", "value"]
               },
               {
                 "type": "object",
@@ -515,8 +602,7 @@
                   "value": {
                     "type": "string"
                   }
-                },
-                "additionalProperties": false
+                }
               }
             ]
           },
@@ -534,8 +620,7 @@
                       "type": "string"
                     }
                   },
-                  "required": ["lang", "value"],
-                  "additionalProperties": false
+                  "required": ["lang", "value"]
                 },
                 {
                   "type": "object",
@@ -546,8 +631,7 @@
                     "value": {
                       "type": "string"
                     }
-                  },
-                  "additionalProperties": false
+                  }
                 }
               ]
             }
@@ -565,8 +649,7 @@
             "type": "string"
           }
         },
-        "required": ["id", "userTypeString", "userType", "version", "name"],
-        "additionalProperties": false
+        "required": ["id", "userTypeString", "userType", "version", "name"]
       }
     },
     "cityZones": {
@@ -597,8 +680,7 @@
                       "type": "string"
                     }
                   },
-                  "required": ["lang", "value"],
-                  "additionalProperties": false
+                  "required": ["lang", "value"]
                 },
                 {
                   "type": "object",
@@ -609,8 +691,7 @@
                     "value": {
                       "type": "string"
                     }
-                  },
-                  "additionalProperties": false
+                  }
                 }
               ]
             }
@@ -629,8 +710,7 @@
                       "type": "string"
                     }
                   },
-                  "required": ["lang", "value"],
-                  "additionalProperties": false
+                  "required": ["lang", "value"]
                 },
                 {
                   "type": "object",
@@ -641,8 +721,7 @@
                     "value": {
                       "type": "string"
                     }
-                  },
-                  "additionalProperties": false
+                  }
                 }
               ]
             }
@@ -672,12 +751,10 @@
                 }
               }
             },
-            "required": ["type", "coordinates"],
-            "additionalProperties": false
+            "required": ["type", "coordinates"]
           }
         },
-        "required": ["id", "name", "enabled", "geometry"],
-        "additionalProperties": false
+        "required": ["id", "name", "enabled", "geometry"]
       }
     },
     "carPoolingZones": {
@@ -713,12 +790,10 @@
                 }
               }
             },
-            "required": ["type", "coordinates"],
-            "additionalProperties": false
+            "required": ["type", "coordinates"]
           }
         },
-        "required": ["id", "name", "geometry"],
-        "additionalProperties": false
+        "required": ["id", "name", "geometry"]
       }
     },
     "preassignedFareProducts": {},
@@ -742,8 +817,7 @@
                     "type": "string"
                   }
                 },
-                "required": ["lang", "value"],
-                "additionalProperties": false
+                "required": ["lang", "value"]
               },
               {
                 "type": "object",
@@ -754,8 +828,7 @@
                   "value": {
                     "type": "string"
                   }
-                },
-                "additionalProperties": false
+                }
               }
             ]
           },
@@ -784,8 +857,7 @@
                 }
               }
             },
-            "required": ["type", "coordinates"],
-            "additionalProperties": false
+            "required": ["type", "coordinates"]
           },
           "description": {
             "type": "array",
@@ -801,8 +873,7 @@
                       "type": "string"
                     }
                   },
-                  "required": ["lang", "value"],
-                  "additionalProperties": false
+                  "required": ["lang", "value"]
                 },
                 {
                   "type": "object",
@@ -813,8 +884,7 @@
                     "value": {
                       "type": "string"
                     }
-                  },
-                  "additionalProperties": false
+                  }
                 }
               ]
             }
@@ -823,8 +893,7 @@
             "type": "boolean"
           }
         },
-        "required": ["id", "name", "version", "geometry"],
-        "additionalProperties": false
+        "required": ["id", "name", "version", "geometry"]
       }
     }
   },
@@ -834,6 +903,5 @@
     "userProfiles",
     "preassignedFareProducts",
     "tariffZones"
-  ],
-  "additionalProperties": false
+  ]
 }

--- a/schema-definitions/referenceData.json
+++ b/schema-definitions/referenceData.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "properties": {
     "preassignedFareProducts_v2": {
@@ -60,131 +61,240 @@
                 }
               },
               "appVersionMin": {
-                "type": ["string", "null"]
+                "type": "string"
               },
               "appVersionMax": {
-                "type": ["string", "null"]
+                "type": "string"
               },
               "fareZoneRefs": {
-                "anyOf": [
-                  {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               },
               "tariffZoneRefs": {
-                "anyOf": [
-                  {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               }
             },
             "required": ["userProfileRefs"],
             "additionalProperties": false
           },
           "durationDays": {
-            "type": ["number", "null"]
+            "type": "number"
           },
           "isApplicableOnSingleZoneOnly": {
-            "type": ["boolean", "null"]
+            "type": "boolean"
           },
           "isBookingEnabled": {
-            "type": ["boolean", "null"]
+            "type": "boolean"
           },
           "isEnabledForTripSearchOffer": {
-            "type": ["boolean", "null"]
+            "type": "boolean"
           },
           "isDefault": {
-            "type": ["boolean", "null"]
+            "type": "boolean"
           },
           "alternativeNames": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/properties/preassignedFareProducts_v2/items/properties/name"
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "lang": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["lang", "value"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "language": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
                 }
-              },
-              {
-                "type": "null"
-              }
-            ]
+              ]
+            }
           },
           "zoneSelectionMode": {
             "anyOf": [
               {
                 "type": "string",
-                "enum": [
-                  "none",
-                  "single",
-                  "single-stop",
-                  "single-zone",
-                  "multiple",
-                  "multiple-stop",
-                  "multiple-zone",
-                  "multiple-stop-harbor"
-                ]
+                "const": "none"
               },
               {
-                "type": "null"
+                "type": "string",
+                "const": "single"
+              },
+              {
+                "type": "string",
+                "const": "single-stop"
+              },
+              {
+                "type": "string",
+                "const": "single-zone"
+              },
+              {
+                "type": "string",
+                "const": "multiple"
+              },
+              {
+                "type": "string",
+                "const": "multiple-stop"
+              },
+              {
+                "type": "string",
+                "const": "multiple-zone"
+              },
+              {
+                "type": "string",
+                "const": "multiple-stop-harbor"
               }
             ]
           },
           "description": {
-            "anyOf": [
-              {
-                "$ref": "#/properties/preassignedFareProducts_v2/items/properties/alternativeNames/anyOf/0"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "lang": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["lang", "value"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "language": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
           },
           "productDescription": {
-            "anyOf": [
-              {
-                "$ref": "#/properties/preassignedFareProducts_v2/items/properties/alternativeNames/anyOf/0"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "lang": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["lang", "value"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "language": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
           },
           "productAliasId": {
-            "type": ["string", "null"]
+            "type": "string"
           },
           "productAlias": {
-            "anyOf": [
-              {
-                "$ref": "#/properties/preassignedFareProducts_v2/items/properties/alternativeNames/anyOf/0"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "lang": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["lang", "value"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "language": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
           },
           "warningMessage": {
-            "anyOf": [
-              {
-                "$ref": "#/properties/preassignedFareProducts_v2/items/properties/alternativeNames/anyOf/0"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "lang": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["lang", "value"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "language": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
           }
         },
         "required": [
@@ -207,7 +317,33 @@
             "type": "string"
           },
           "name": {
-            "$ref": "#/properties/preassignedFareProducts_v2/items/properties/name"
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "lang": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": ["lang", "value"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "language": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
           },
           "version": {
             "type": "string"
@@ -224,12 +360,12 @@
                 "items": {
                   "type": "array",
                   "items": {
+                    "minItems": 2,
+                    "maxItems": 2,
                     "type": "array",
                     "items": {
                       "type": "number"
-                    },
-                    "minItems": 2,
-                    "maxItems": 2
+                    }
                   }
                 }
               }
@@ -238,7 +374,36 @@
             "additionalProperties": false
           },
           "description": {
-            "$ref": "#/properties/preassignedFareProducts_v2/items/properties/alternativeNames/anyOf/0"
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "lang": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["lang", "value"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "language": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
           },
           "isDefault": {
             "type": "boolean"
@@ -266,16 +431,126 @@
             "type": "string"
           },
           "name": {
-            "$ref": "#/properties/preassignedFareProducts_v2/items/properties/name"
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "lang": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": ["lang", "value"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "language": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
           },
           "alternativeNames": {
-            "$ref": "#/properties/preassignedFareProducts_v2/items/properties/alternativeNames/anyOf/0"
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "lang": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["lang", "value"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "language": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
           },
           "description": {
-            "$ref": "#/properties/preassignedFareProducts_v2/items/properties/name"
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "lang": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": ["lang", "value"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "language": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
           },
           "alternativeDescriptions": {
-            "$ref": "#/properties/preassignedFareProducts_v2/items/properties/alternativeNames/anyOf/0"
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "lang": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["lang", "value"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "language": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
           },
           "hideFromDefaultTravellerSelection": {
             "type": "boolean"
@@ -309,10 +584,68 @@
             "type": "boolean"
           },
           "moreInfoUrl": {
-            "$ref": "#/properties/preassignedFareProducts_v2/items/properties/alternativeNames/anyOf/0"
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "lang": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["lang", "value"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "language": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
           },
           "orderUrl": {
-            "$ref": "#/properties/preassignedFareProducts_v2/items/properties/alternativeNames/anyOf/0"
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "lang": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["lang", "value"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "language": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
           },
           "phoneNumber": {
             "type": "string"
@@ -329,12 +662,12 @@
                 "items": {
                   "type": "array",
                   "items": {
+                    "minItems": 2,
+                    "maxItems": 2,
                     "type": "array",
                     "items": {
                       "type": "number"
-                    },
-                    "minItems": 2,
-                    "maxItems": 2
+                    }
                   }
                 }
               }
@@ -370,12 +703,12 @@
                 "items": {
                   "type": "array",
                   "items": {
+                    "minItems": 2,
+                    "maxItems": 2,
                     "type": "array",
                     "items": {
                       "type": "number"
-                    },
-                    "minItems": 2,
-                    "maxItems": 2
+                    }
                   }
                 }
               }
@@ -398,7 +731,33 @@
             "type": "string"
           },
           "name": {
-            "$ref": "#/properties/preassignedFareProducts_v2/items/properties/name"
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "lang": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": ["lang", "value"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "language": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
           },
           "version": {
             "type": "string"
@@ -415,12 +774,12 @@
                 "items": {
                   "type": "array",
                   "items": {
+                    "minItems": 2,
+                    "maxItems": 2,
                     "type": "array",
                     "items": {
                       "type": "number"
-                    },
-                    "minItems": 2,
-                    "maxItems": 2
+                    }
                   }
                 }
               }
@@ -429,7 +788,36 @@
             "additionalProperties": false
           },
           "description": {
-            "$ref": "#/properties/preassignedFareProducts_v2/items/properties/alternativeNames/anyOf/0"
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "lang": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["lang", "value"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "language": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
           },
           "isDefault": {
             "type": "boolean"
@@ -444,8 +832,8 @@
     "preassignedFareProducts_v2",
     "fareZones",
     "userProfiles",
+    "preassignedFareProducts",
     "tariffZones"
   ],
-  "additionalProperties": false,
-  "$schema": "http://json-schema.org/draft-07/schema#"
+  "additionalProperties": false
 }

--- a/schema-definitions/stopSignalButtonConfig.json
+++ b/schema-definitions/stopSignalButtonConfig.json
@@ -1,166 +1,16 @@
 {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "properties": {
     "activationWindowStartMinutesBefore": {
-      "type": "number",
-      "default": 60
+      "default": 60,
+      "type": "number"
     },
     "activationWindowEndMinutesBefore": {
-      "type": "number",
-      "default": 2
+      "default": 2,
+      "type": "number"
     },
     "modes": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "mode": {
-            "type": "string",
-            "enum": [
-              "bicycle",
-              "foot",
-              "scooter",
-              "air",
-              "bus",
-              "cableway",
-              "coach",
-              "funicular",
-              "lift",
-              "metro",
-              "monorail",
-              "rail",
-              "taxi",
-              "tram",
-              "trolleybus",
-              "unknown",
-              "water"
-            ]
-          },
-          "submodes": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "enum": [
-                "escooter",
-                "SchengenAreaFlight",
-                "airportBoatLink",
-                "airportLinkBus",
-                "airportLinkRail",
-                "airshipService",
-                "allFunicularServices",
-                "allHireVehicles",
-                "allTaxiServices",
-                "bikeTaxi",
-                "blackCab",
-                "cableCar",
-                "cableFerry",
-                "canalBarge",
-                "carTransportRailService",
-                "chairLift",
-                "charterTaxi",
-                "cityTram",
-                "communalTaxi",
-                "commuterCoach",
-                "crossCountryRail",
-                "dedicatedLaneBus",
-                "demandAndResponseBus",
-                "domesticCharterFlight",
-                "domesticFlight",
-                "domesticScheduledFlight",
-                "dragLift",
-                "expressBus",
-                "funicular",
-                "helicopterService",
-                "highFrequencyBus",
-                "highSpeedPassengerService",
-                "highSpeedRail",
-                "highSpeedVehicleService",
-                "hireCar",
-                "hireCycle",
-                "hireMotorbike",
-                "hireVan",
-                "intercontinentalCharterFlight",
-                "intercontinentalFlight",
-                "international",
-                "internationalCarFerry",
-                "internationalCharterFlight",
-                "internationalCoach",
-                "internationalFlight",
-                "internationalPassengerFerry",
-                "interregionalRail",
-                "lift",
-                "local",
-                "localBus",
-                "localCarFerry",
-                "localPassengerFerry",
-                "localTram",
-                "longDistance",
-                "metro",
-                "miniCab",
-                "mobilityBus",
-                "mobilityBusForRegisteredDisabled",
-                "nationalCarFerry",
-                "nationalCoach",
-                "nationalPassengerFerry",
-                "nightBus",
-                "nightRail",
-                "postBoat",
-                "postBus",
-                "rackAndPinionRailway",
-                "railReplacementBus",
-                "railShuttle",
-                "railTaxi",
-                "regionalBus",
-                "regionalCarFerry",
-                "regionalCoach",
-                "regionalPassengerFerry",
-                "regionalRail",
-                "regionalTram",
-                "replacementRailService",
-                "riverBus",
-                "roadFerryLink",
-                "roundTripCharterFlight",
-                "scheduledFerry",
-                "schoolAndPublicServiceBus",
-                "schoolBoat",
-                "schoolBus",
-                "schoolCoach",
-                "shortHaulInternationalFlight",
-                "shuttleBus",
-                "shuttleCoach",
-                "shuttleFerryService",
-                "shuttleFlight",
-                "shuttleTram",
-                "sightseeingBus",
-                "sightseeingCoach",
-                "sightseeingFlight",
-                "sightseeingService",
-                "sightseeingTram",
-                "sleeperRailService",
-                "specialCoach",
-                "specialNeedsBus",
-                "specialTrain",
-                "streetCableCar",
-                "suburbanRailway",
-                "telecabin",
-                "telecabinLink",
-                "touristCoach",
-                "touristRailway",
-                "trainFerry",
-                "trainTram",
-                "tube",
-                "undefined",
-                "undefinedFunicular",
-                "unknown",
-                "urbanRailway",
-                "waterTaxi"
-              ]
-            }
-          }
-        },
-        "required": ["mode"],
-        "additionalProperties": false
-      },
       "default": [
         {
           "mode": "bus"
@@ -168,9 +18,552 @@
         {
           "mode": "tram"
         }
-      ]
+      ],
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "mode": {
+            "anyOf": [
+              {
+                "type": "string",
+                "const": "bicycle"
+              },
+              {
+                "type": "string",
+                "const": "foot"
+              },
+              {
+                "type": "string",
+                "const": "scooter"
+              },
+              {
+                "type": "string",
+                "const": "air"
+              },
+              {
+                "type": "string",
+                "const": "bus"
+              },
+              {
+                "type": "string",
+                "const": "cableway"
+              },
+              {
+                "type": "string",
+                "const": "coach"
+              },
+              {
+                "type": "string",
+                "const": "funicular"
+              },
+              {
+                "type": "string",
+                "const": "lift"
+              },
+              {
+                "type": "string",
+                "const": "metro"
+              },
+              {
+                "type": "string",
+                "const": "monorail"
+              },
+              {
+                "type": "string",
+                "const": "rail"
+              },
+              {
+                "type": "string",
+                "const": "taxi"
+              },
+              {
+                "type": "string",
+                "const": "tram"
+              },
+              {
+                "type": "string",
+                "const": "trolleybus"
+              },
+              {
+                "type": "string",
+                "const": "unknown"
+              },
+              {
+                "type": "string",
+                "const": "water"
+              }
+            ]
+          },
+          "submodes": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "const": "escooter"
+                },
+                {
+                  "type": "string",
+                  "const": "SchengenAreaFlight"
+                },
+                {
+                  "type": "string",
+                  "const": "airportBoatLink"
+                },
+                {
+                  "type": "string",
+                  "const": "airportLinkBus"
+                },
+                {
+                  "type": "string",
+                  "const": "airportLinkRail"
+                },
+                {
+                  "type": "string",
+                  "const": "airshipService"
+                },
+                {
+                  "type": "string",
+                  "const": "allFunicularServices"
+                },
+                {
+                  "type": "string",
+                  "const": "allHireVehicles"
+                },
+                {
+                  "type": "string",
+                  "const": "allTaxiServices"
+                },
+                {
+                  "type": "string",
+                  "const": "bikeTaxi"
+                },
+                {
+                  "type": "string",
+                  "const": "blackCab"
+                },
+                {
+                  "type": "string",
+                  "const": "cableCar"
+                },
+                {
+                  "type": "string",
+                  "const": "cableFerry"
+                },
+                {
+                  "type": "string",
+                  "const": "canalBarge"
+                },
+                {
+                  "type": "string",
+                  "const": "carTransportRailService"
+                },
+                {
+                  "type": "string",
+                  "const": "chairLift"
+                },
+                {
+                  "type": "string",
+                  "const": "charterTaxi"
+                },
+                {
+                  "type": "string",
+                  "const": "cityTram"
+                },
+                {
+                  "type": "string",
+                  "const": "communalTaxi"
+                },
+                {
+                  "type": "string",
+                  "const": "commuterCoach"
+                },
+                {
+                  "type": "string",
+                  "const": "crossCountryRail"
+                },
+                {
+                  "type": "string",
+                  "const": "dedicatedLaneBus"
+                },
+                {
+                  "type": "string",
+                  "const": "demandAndResponseBus"
+                },
+                {
+                  "type": "string",
+                  "const": "domesticCharterFlight"
+                },
+                {
+                  "type": "string",
+                  "const": "domesticFlight"
+                },
+                {
+                  "type": "string",
+                  "const": "domesticScheduledFlight"
+                },
+                {
+                  "type": "string",
+                  "const": "dragLift"
+                },
+                {
+                  "type": "string",
+                  "const": "expressBus"
+                },
+                {
+                  "type": "string",
+                  "const": "funicular"
+                },
+                {
+                  "type": "string",
+                  "const": "helicopterService"
+                },
+                {
+                  "type": "string",
+                  "const": "highFrequencyBus"
+                },
+                {
+                  "type": "string",
+                  "const": "highSpeedPassengerService"
+                },
+                {
+                  "type": "string",
+                  "const": "highSpeedRail"
+                },
+                {
+                  "type": "string",
+                  "const": "highSpeedVehicleService"
+                },
+                {
+                  "type": "string",
+                  "const": "hireCar"
+                },
+                {
+                  "type": "string",
+                  "const": "hireCycle"
+                },
+                {
+                  "type": "string",
+                  "const": "hireMotorbike"
+                },
+                {
+                  "type": "string",
+                  "const": "hireVan"
+                },
+                {
+                  "type": "string",
+                  "const": "intercontinentalCharterFlight"
+                },
+                {
+                  "type": "string",
+                  "const": "intercontinentalFlight"
+                },
+                {
+                  "type": "string",
+                  "const": "international"
+                },
+                {
+                  "type": "string",
+                  "const": "internationalCarFerry"
+                },
+                {
+                  "type": "string",
+                  "const": "internationalCharterFlight"
+                },
+                {
+                  "type": "string",
+                  "const": "internationalCoach"
+                },
+                {
+                  "type": "string",
+                  "const": "internationalFlight"
+                },
+                {
+                  "type": "string",
+                  "const": "internationalPassengerFerry"
+                },
+                {
+                  "type": "string",
+                  "const": "interregionalRail"
+                },
+                {
+                  "type": "string",
+                  "const": "lift"
+                },
+                {
+                  "type": "string",
+                  "const": "local"
+                },
+                {
+                  "type": "string",
+                  "const": "localBus"
+                },
+                {
+                  "type": "string",
+                  "const": "localCarFerry"
+                },
+                {
+                  "type": "string",
+                  "const": "localPassengerFerry"
+                },
+                {
+                  "type": "string",
+                  "const": "localTram"
+                },
+                {
+                  "type": "string",
+                  "const": "longDistance"
+                },
+                {
+                  "type": "string",
+                  "const": "metro"
+                },
+                {
+                  "type": "string",
+                  "const": "miniCab"
+                },
+                {
+                  "type": "string",
+                  "const": "mobilityBus"
+                },
+                {
+                  "type": "string",
+                  "const": "mobilityBusForRegisteredDisabled"
+                },
+                {
+                  "type": "string",
+                  "const": "nationalCarFerry"
+                },
+                {
+                  "type": "string",
+                  "const": "nationalCoach"
+                },
+                {
+                  "type": "string",
+                  "const": "nationalPassengerFerry"
+                },
+                {
+                  "type": "string",
+                  "const": "nightBus"
+                },
+                {
+                  "type": "string",
+                  "const": "nightRail"
+                },
+                {
+                  "type": "string",
+                  "const": "postBoat"
+                },
+                {
+                  "type": "string",
+                  "const": "postBus"
+                },
+                {
+                  "type": "string",
+                  "const": "rackAndPinionRailway"
+                },
+                {
+                  "type": "string",
+                  "const": "railReplacementBus"
+                },
+                {
+                  "type": "string",
+                  "const": "railShuttle"
+                },
+                {
+                  "type": "string",
+                  "const": "railTaxi"
+                },
+                {
+                  "type": "string",
+                  "const": "regionalBus"
+                },
+                {
+                  "type": "string",
+                  "const": "regionalCarFerry"
+                },
+                {
+                  "type": "string",
+                  "const": "regionalCoach"
+                },
+                {
+                  "type": "string",
+                  "const": "regionalPassengerFerry"
+                },
+                {
+                  "type": "string",
+                  "const": "regionalRail"
+                },
+                {
+                  "type": "string",
+                  "const": "regionalTram"
+                },
+                {
+                  "type": "string",
+                  "const": "replacementRailService"
+                },
+                {
+                  "type": "string",
+                  "const": "riverBus"
+                },
+                {
+                  "type": "string",
+                  "const": "roadFerryLink"
+                },
+                {
+                  "type": "string",
+                  "const": "roundTripCharterFlight"
+                },
+                {
+                  "type": "string",
+                  "const": "scheduledFerry"
+                },
+                {
+                  "type": "string",
+                  "const": "schoolAndPublicServiceBus"
+                },
+                {
+                  "type": "string",
+                  "const": "schoolBoat"
+                },
+                {
+                  "type": "string",
+                  "const": "schoolBus"
+                },
+                {
+                  "type": "string",
+                  "const": "schoolCoach"
+                },
+                {
+                  "type": "string",
+                  "const": "shortHaulInternationalFlight"
+                },
+                {
+                  "type": "string",
+                  "const": "shuttleBus"
+                },
+                {
+                  "type": "string",
+                  "const": "shuttleCoach"
+                },
+                {
+                  "type": "string",
+                  "const": "shuttleFerryService"
+                },
+                {
+                  "type": "string",
+                  "const": "shuttleFlight"
+                },
+                {
+                  "type": "string",
+                  "const": "shuttleTram"
+                },
+                {
+                  "type": "string",
+                  "const": "sightseeingBus"
+                },
+                {
+                  "type": "string",
+                  "const": "sightseeingCoach"
+                },
+                {
+                  "type": "string",
+                  "const": "sightseeingFlight"
+                },
+                {
+                  "type": "string",
+                  "const": "sightseeingService"
+                },
+                {
+                  "type": "string",
+                  "const": "sightseeingTram"
+                },
+                {
+                  "type": "string",
+                  "const": "sleeperRailService"
+                },
+                {
+                  "type": "string",
+                  "const": "specialCoach"
+                },
+                {
+                  "type": "string",
+                  "const": "specialNeedsBus"
+                },
+                {
+                  "type": "string",
+                  "const": "specialTrain"
+                },
+                {
+                  "type": "string",
+                  "const": "streetCableCar"
+                },
+                {
+                  "type": "string",
+                  "const": "suburbanRailway"
+                },
+                {
+                  "type": "string",
+                  "const": "telecabin"
+                },
+                {
+                  "type": "string",
+                  "const": "telecabinLink"
+                },
+                {
+                  "type": "string",
+                  "const": "touristCoach"
+                },
+                {
+                  "type": "string",
+                  "const": "touristRailway"
+                },
+                {
+                  "type": "string",
+                  "const": "trainFerry"
+                },
+                {
+                  "type": "string",
+                  "const": "trainTram"
+                },
+                {
+                  "type": "string",
+                  "const": "tube"
+                },
+                {
+                  "type": "string",
+                  "const": "undefined"
+                },
+                {
+                  "type": "string",
+                  "const": "undefinedFunicular"
+                },
+                {
+                  "type": "string",
+                  "const": "unknown"
+                },
+                {
+                  "type": "string",
+                  "const": "urbanRailway"
+                },
+                {
+                  "type": "string",
+                  "const": "waterTaxi"
+                }
+              ]
+            }
+          }
+        },
+        "required": ["mode"],
+        "additionalProperties": false
+      }
     }
   },
-  "additionalProperties": false,
-  "$schema": "http://json-schema.org/draft-07/schema#"
+  "required": [
+    "activationWindowStartMinutesBefore",
+    "activationWindowEndMinutesBefore",
+    "modes"
+  ],
+  "additionalProperties": false
 }

--- a/schema-definitions/travelSearchFilters.json
+++ b/schema-definitions/travelSearchFilters.json
@@ -1,332 +1,1376 @@
 {
-  "$ref": "#/definitions/TravelSearchFilters",
-  "definitions": {
-    "LanguageAndTextTypeArray": {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "TravelSearchFilters",
+  "type": "object",
+  "properties": {
+    "transportModes": {
       "type": "array",
       "items": {
-        "anyOf": [
-          {
-            "type": "object",
-            "properties": {
-              "lang": {
-                "type": "string"
-              },
-              "value": {
-                "type": "string"
-              }
-            },
-            "required": ["lang", "value"],
-            "additionalProperties": false
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
           },
-          {
+          "icon": {
             "type": "object",
             "properties": {
-              "language": {
-                "type": "string"
-              },
-              "value": {
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          }
-        ]
-      }
-    },
-    "TravelSearchTransportModes": {
-      "type": "object",
-      "properties": {
-        "transportMode": {
-          "$ref": "#/definitions/TransportModeType"
-        },
-        "transportSubModes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/TransportSubmodeType"
-          }
-        }
-      },
-      "required": ["transportMode"],
-      "additionalProperties": false
-    },
-    "TravelSearchTransportModeIcon": {
-      "type": "object",
-      "properties": {
-        "transportMode": {
-          "$ref": "#/definitions/TransportModeType"
-        },
-        "transportSubMode": {
-          "$ref": "#/definitions/TransportSubmodeType"
-        }
-      },
-      "required": ["transportMode"],
-      "additionalProperties": false
-    },
-    "TransportModeType": {
-      "type": "string",
-      "enum": [
-        "bicycle",
-        "foot",
-        "scooter",
-        "air",
-        "bus",
-        "cableway",
-        "coach",
-        "funicular",
-        "lift",
-        "metro",
-        "monorail",
-        "rail",
-        "taxi",
-        "tram",
-        "trolleybus",
-        "unknown",
-        "water"
-      ]
-    },
-    "TransportSubmodeType": {
-      "type": "string",
-      "enum": [
-        "escooter",
-        "SchengenAreaFlight",
-        "airportBoatLink",
-        "airportLinkBus",
-        "airportLinkRail",
-        "airshipService",
-        "allFunicularServices",
-        "allHireVehicles",
-        "allTaxiServices",
-        "bikeTaxi",
-        "blackCab",
-        "cableCar",
-        "cableFerry",
-        "canalBarge",
-        "carTransportRailService",
-        "chairLift",
-        "charterTaxi",
-        "cityTram",
-        "communalTaxi",
-        "commuterCoach",
-        "crossCountryRail",
-        "dedicatedLaneBus",
-        "demandAndResponseBus",
-        "domesticCharterFlight",
-        "domesticFlight",
-        "domesticScheduledFlight",
-        "dragLift",
-        "expressBus",
-        "funicular",
-        "helicopterService",
-        "highFrequencyBus",
-        "highSpeedPassengerService",
-        "highSpeedRail",
-        "highSpeedVehicleService",
-        "hireCar",
-        "hireCycle",
-        "hireMotorbike",
-        "hireVan",
-        "intercontinentalCharterFlight",
-        "intercontinentalFlight",
-        "international",
-        "internationalCarFerry",
-        "internationalCharterFlight",
-        "internationalCoach",
-        "internationalFlight",
-        "internationalPassengerFerry",
-        "interregionalRail",
-        "lift",
-        "local",
-        "localBus",
-        "localCarFerry",
-        "localPassengerFerry",
-        "localTram",
-        "longDistance",
-        "metro",
-        "miniCab",
-        "mobilityBus",
-        "mobilityBusForRegisteredDisabled",
-        "nationalCarFerry",
-        "nationalCoach",
-        "nationalPassengerFerry",
-        "nightBus",
-        "nightRail",
-        "postBoat",
-        "postBus",
-        "rackAndPinionRailway",
-        "railReplacementBus",
-        "railShuttle",
-        "railTaxi",
-        "regionalBus",
-        "regionalCarFerry",
-        "regionalCoach",
-        "regionalPassengerFerry",
-        "regionalRail",
-        "regionalTram",
-        "replacementRailService",
-        "riverBus",
-        "roadFerryLink",
-        "roundTripCharterFlight",
-        "scheduledFerry",
-        "schoolAndPublicServiceBus",
-        "schoolBoat",
-        "schoolBus",
-        "schoolCoach",
-        "shortHaulInternationalFlight",
-        "shuttleBus",
-        "shuttleCoach",
-        "shuttleFerryService",
-        "shuttleFlight",
-        "shuttleTram",
-        "sightseeingBus",
-        "sightseeingCoach",
-        "sightseeingFlight",
-        "sightseeingService",
-        "sightseeingTram",
-        "sleeperRailService",
-        "specialCoach",
-        "specialNeedsBus",
-        "specialTrain",
-        "streetCableCar",
-        "suburbanRailway",
-        "telecabin",
-        "telecabinLink",
-        "touristCoach",
-        "touristRailway",
-        "trainFerry",
-        "trainTram",
-        "tube",
-        "undefined",
-        "undefinedFunicular",
-        "unknown",
-        "urbanRailway",
-        "waterTaxi"
-      ]
-    },
-    "TravelSearchFilters": {
-      "type": "object",
-      "properties": {
-        "transportModes": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string"
-              },
-              "icon": {
-                "$ref": "#/definitions/TravelSearchTransportModeIcon"
-              },
-              "text": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/LanguageAndTextTypeArray/items"
-                },
-                "minItems": 1
-              },
-              "description": {
-                "$ref": "#/definitions/LanguageAndTextTypeArray"
-              },
-              "modes": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/TravelSearchTransportModes"
-                }
-              },
-              "selectedAsDefault": {
-                "type": "boolean"
-              }
-            },
-            "required": ["id", "icon", "text", "modes", "selectedAsDefault"],
-            "additionalProperties": false
-          }
-        },
-        "flexibleTransport": {
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": "string"
-            },
-            "title": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/LanguageAndTextTypeArray/items"
-              },
-              "minItems": 1
-            },
-            "label": {
-              "type": "string",
-              "enum": ["beta", "new"]
-            },
-            "description": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/LanguageAndTextTypeArray/items"
-              },
-              "minItems": 1
-            }
-          },
-          "required": ["id", "title", "description"],
-          "additionalProperties": false
-        },
-        "travelSearchPreferences": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "transferSlack",
-                  "transferPenalty",
-                  "waitReluctance",
-                  "walkReluctance",
-                  "walkSpeed"
+              "transportMode": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "const": "bicycle"
+                  },
+                  {
+                    "type": "string",
+                    "const": "foot"
+                  },
+                  {
+                    "type": "string",
+                    "const": "scooter"
+                  },
+                  {
+                    "type": "string",
+                    "const": "air"
+                  },
+                  {
+                    "type": "string",
+                    "const": "bus"
+                  },
+                  {
+                    "type": "string",
+                    "const": "cableway"
+                  },
+                  {
+                    "type": "string",
+                    "const": "coach"
+                  },
+                  {
+                    "type": "string",
+                    "const": "funicular"
+                  },
+                  {
+                    "type": "string",
+                    "const": "lift"
+                  },
+                  {
+                    "type": "string",
+                    "const": "metro"
+                  },
+                  {
+                    "type": "string",
+                    "const": "monorail"
+                  },
+                  {
+                    "type": "string",
+                    "const": "rail"
+                  },
+                  {
+                    "type": "string",
+                    "const": "taxi"
+                  },
+                  {
+                    "type": "string",
+                    "const": "tram"
+                  },
+                  {
+                    "type": "string",
+                    "const": "trolleybus"
+                  },
+                  {
+                    "type": "string",
+                    "const": "unknown"
+                  },
+                  {
+                    "type": "string",
+                    "const": "water"
+                  }
                 ]
               },
-              "title": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/LanguageAndTextTypeArray/items"
-                },
-                "minItems": 1
-              },
-              "options": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "minLength": 1
-                    },
-                    "text": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/definitions/LanguageAndTextTypeArray/items"
-                      },
-                      "minItems": 1
-                    },
-                    "value": {
-                      "type": "number",
-                      "minimum": 0
-                    }
+              "transportSubMode": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "const": "escooter"
                   },
-                  "required": ["id", "text", "value"],
-                  "additionalProperties": false
-                },
-                "minItems": 1
-              },
-              "defaultOption": {
-                "$ref": "#/definitions/TravelSearchFilters/properties/travelSearchPreferences/items/properties/options/items/properties/id"
+                  {
+                    "type": "string",
+                    "const": "SchengenAreaFlight"
+                  },
+                  {
+                    "type": "string",
+                    "const": "airportBoatLink"
+                  },
+                  {
+                    "type": "string",
+                    "const": "airportLinkBus"
+                  },
+                  {
+                    "type": "string",
+                    "const": "airportLinkRail"
+                  },
+                  {
+                    "type": "string",
+                    "const": "airshipService"
+                  },
+                  {
+                    "type": "string",
+                    "const": "allFunicularServices"
+                  },
+                  {
+                    "type": "string",
+                    "const": "allHireVehicles"
+                  },
+                  {
+                    "type": "string",
+                    "const": "allTaxiServices"
+                  },
+                  {
+                    "type": "string",
+                    "const": "bikeTaxi"
+                  },
+                  {
+                    "type": "string",
+                    "const": "blackCab"
+                  },
+                  {
+                    "type": "string",
+                    "const": "cableCar"
+                  },
+                  {
+                    "type": "string",
+                    "const": "cableFerry"
+                  },
+                  {
+                    "type": "string",
+                    "const": "canalBarge"
+                  },
+                  {
+                    "type": "string",
+                    "const": "carTransportRailService"
+                  },
+                  {
+                    "type": "string",
+                    "const": "chairLift"
+                  },
+                  {
+                    "type": "string",
+                    "const": "charterTaxi"
+                  },
+                  {
+                    "type": "string",
+                    "const": "cityTram"
+                  },
+                  {
+                    "type": "string",
+                    "const": "communalTaxi"
+                  },
+                  {
+                    "type": "string",
+                    "const": "commuterCoach"
+                  },
+                  {
+                    "type": "string",
+                    "const": "crossCountryRail"
+                  },
+                  {
+                    "type": "string",
+                    "const": "dedicatedLaneBus"
+                  },
+                  {
+                    "type": "string",
+                    "const": "demandAndResponseBus"
+                  },
+                  {
+                    "type": "string",
+                    "const": "domesticCharterFlight"
+                  },
+                  {
+                    "type": "string",
+                    "const": "domesticFlight"
+                  },
+                  {
+                    "type": "string",
+                    "const": "domesticScheduledFlight"
+                  },
+                  {
+                    "type": "string",
+                    "const": "dragLift"
+                  },
+                  {
+                    "type": "string",
+                    "const": "expressBus"
+                  },
+                  {
+                    "type": "string",
+                    "const": "funicular"
+                  },
+                  {
+                    "type": "string",
+                    "const": "helicopterService"
+                  },
+                  {
+                    "type": "string",
+                    "const": "highFrequencyBus"
+                  },
+                  {
+                    "type": "string",
+                    "const": "highSpeedPassengerService"
+                  },
+                  {
+                    "type": "string",
+                    "const": "highSpeedRail"
+                  },
+                  {
+                    "type": "string",
+                    "const": "highSpeedVehicleService"
+                  },
+                  {
+                    "type": "string",
+                    "const": "hireCar"
+                  },
+                  {
+                    "type": "string",
+                    "const": "hireCycle"
+                  },
+                  {
+                    "type": "string",
+                    "const": "hireMotorbike"
+                  },
+                  {
+                    "type": "string",
+                    "const": "hireVan"
+                  },
+                  {
+                    "type": "string",
+                    "const": "intercontinentalCharterFlight"
+                  },
+                  {
+                    "type": "string",
+                    "const": "intercontinentalFlight"
+                  },
+                  {
+                    "type": "string",
+                    "const": "international"
+                  },
+                  {
+                    "type": "string",
+                    "const": "internationalCarFerry"
+                  },
+                  {
+                    "type": "string",
+                    "const": "internationalCharterFlight"
+                  },
+                  {
+                    "type": "string",
+                    "const": "internationalCoach"
+                  },
+                  {
+                    "type": "string",
+                    "const": "internationalFlight"
+                  },
+                  {
+                    "type": "string",
+                    "const": "internationalPassengerFerry"
+                  },
+                  {
+                    "type": "string",
+                    "const": "interregionalRail"
+                  },
+                  {
+                    "type": "string",
+                    "const": "lift"
+                  },
+                  {
+                    "type": "string",
+                    "const": "local"
+                  },
+                  {
+                    "type": "string",
+                    "const": "localBus"
+                  },
+                  {
+                    "type": "string",
+                    "const": "localCarFerry"
+                  },
+                  {
+                    "type": "string",
+                    "const": "localPassengerFerry"
+                  },
+                  {
+                    "type": "string",
+                    "const": "localTram"
+                  },
+                  {
+                    "type": "string",
+                    "const": "longDistance"
+                  },
+                  {
+                    "type": "string",
+                    "const": "metro"
+                  },
+                  {
+                    "type": "string",
+                    "const": "miniCab"
+                  },
+                  {
+                    "type": "string",
+                    "const": "mobilityBus"
+                  },
+                  {
+                    "type": "string",
+                    "const": "mobilityBusForRegisteredDisabled"
+                  },
+                  {
+                    "type": "string",
+                    "const": "nationalCarFerry"
+                  },
+                  {
+                    "type": "string",
+                    "const": "nationalCoach"
+                  },
+                  {
+                    "type": "string",
+                    "const": "nationalPassengerFerry"
+                  },
+                  {
+                    "type": "string",
+                    "const": "nightBus"
+                  },
+                  {
+                    "type": "string",
+                    "const": "nightRail"
+                  },
+                  {
+                    "type": "string",
+                    "const": "postBoat"
+                  },
+                  {
+                    "type": "string",
+                    "const": "postBus"
+                  },
+                  {
+                    "type": "string",
+                    "const": "rackAndPinionRailway"
+                  },
+                  {
+                    "type": "string",
+                    "const": "railReplacementBus"
+                  },
+                  {
+                    "type": "string",
+                    "const": "railShuttle"
+                  },
+                  {
+                    "type": "string",
+                    "const": "railTaxi"
+                  },
+                  {
+                    "type": "string",
+                    "const": "regionalBus"
+                  },
+                  {
+                    "type": "string",
+                    "const": "regionalCarFerry"
+                  },
+                  {
+                    "type": "string",
+                    "const": "regionalCoach"
+                  },
+                  {
+                    "type": "string",
+                    "const": "regionalPassengerFerry"
+                  },
+                  {
+                    "type": "string",
+                    "const": "regionalRail"
+                  },
+                  {
+                    "type": "string",
+                    "const": "regionalTram"
+                  },
+                  {
+                    "type": "string",
+                    "const": "replacementRailService"
+                  },
+                  {
+                    "type": "string",
+                    "const": "riverBus"
+                  },
+                  {
+                    "type": "string",
+                    "const": "roadFerryLink"
+                  },
+                  {
+                    "type": "string",
+                    "const": "roundTripCharterFlight"
+                  },
+                  {
+                    "type": "string",
+                    "const": "scheduledFerry"
+                  },
+                  {
+                    "type": "string",
+                    "const": "schoolAndPublicServiceBus"
+                  },
+                  {
+                    "type": "string",
+                    "const": "schoolBoat"
+                  },
+                  {
+                    "type": "string",
+                    "const": "schoolBus"
+                  },
+                  {
+                    "type": "string",
+                    "const": "schoolCoach"
+                  },
+                  {
+                    "type": "string",
+                    "const": "shortHaulInternationalFlight"
+                  },
+                  {
+                    "type": "string",
+                    "const": "shuttleBus"
+                  },
+                  {
+                    "type": "string",
+                    "const": "shuttleCoach"
+                  },
+                  {
+                    "type": "string",
+                    "const": "shuttleFerryService"
+                  },
+                  {
+                    "type": "string",
+                    "const": "shuttleFlight"
+                  },
+                  {
+                    "type": "string",
+                    "const": "shuttleTram"
+                  },
+                  {
+                    "type": "string",
+                    "const": "sightseeingBus"
+                  },
+                  {
+                    "type": "string",
+                    "const": "sightseeingCoach"
+                  },
+                  {
+                    "type": "string",
+                    "const": "sightseeingFlight"
+                  },
+                  {
+                    "type": "string",
+                    "const": "sightseeingService"
+                  },
+                  {
+                    "type": "string",
+                    "const": "sightseeingTram"
+                  },
+                  {
+                    "type": "string",
+                    "const": "sleeperRailService"
+                  },
+                  {
+                    "type": "string",
+                    "const": "specialCoach"
+                  },
+                  {
+                    "type": "string",
+                    "const": "specialNeedsBus"
+                  },
+                  {
+                    "type": "string",
+                    "const": "specialTrain"
+                  },
+                  {
+                    "type": "string",
+                    "const": "streetCableCar"
+                  },
+                  {
+                    "type": "string",
+                    "const": "suburbanRailway"
+                  },
+                  {
+                    "type": "string",
+                    "const": "telecabin"
+                  },
+                  {
+                    "type": "string",
+                    "const": "telecabinLink"
+                  },
+                  {
+                    "type": "string",
+                    "const": "touristCoach"
+                  },
+                  {
+                    "type": "string",
+                    "const": "touristRailway"
+                  },
+                  {
+                    "type": "string",
+                    "const": "trainFerry"
+                  },
+                  {
+                    "type": "string",
+                    "const": "trainTram"
+                  },
+                  {
+                    "type": "string",
+                    "const": "tube"
+                  },
+                  {
+                    "type": "string",
+                    "const": "undefined"
+                  },
+                  {
+                    "type": "string",
+                    "const": "undefinedFunicular"
+                  },
+                  {
+                    "type": "string",
+                    "const": "unknown"
+                  },
+                  {
+                    "type": "string",
+                    "const": "urbanRailway"
+                  },
+                  {
+                    "type": "string",
+                    "const": "waterTaxi"
+                  }
+                ]
               }
             },
-            "required": ["type", "title", "options", "defaultOption"],
+            "required": ["transportMode"],
             "additionalProperties": false
+          },
+          "text": {
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "lang": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["lang", "value"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "language": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
+          },
+          "description": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "lang": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["lang", "value"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "language": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
+          },
+          "modes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "transportMode": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "const": "bicycle"
+                    },
+                    {
+                      "type": "string",
+                      "const": "foot"
+                    },
+                    {
+                      "type": "string",
+                      "const": "scooter"
+                    },
+                    {
+                      "type": "string",
+                      "const": "air"
+                    },
+                    {
+                      "type": "string",
+                      "const": "bus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "cableway"
+                    },
+                    {
+                      "type": "string",
+                      "const": "coach"
+                    },
+                    {
+                      "type": "string",
+                      "const": "funicular"
+                    },
+                    {
+                      "type": "string",
+                      "const": "lift"
+                    },
+                    {
+                      "type": "string",
+                      "const": "metro"
+                    },
+                    {
+                      "type": "string",
+                      "const": "monorail"
+                    },
+                    {
+                      "type": "string",
+                      "const": "rail"
+                    },
+                    {
+                      "type": "string",
+                      "const": "taxi"
+                    },
+                    {
+                      "type": "string",
+                      "const": "tram"
+                    },
+                    {
+                      "type": "string",
+                      "const": "trolleybus"
+                    },
+                    {
+                      "type": "string",
+                      "const": "unknown"
+                    },
+                    {
+                      "type": "string",
+                      "const": "water"
+                    }
+                  ]
+                },
+                "transportSubModes": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "const": "escooter"
+                      },
+                      {
+                        "type": "string",
+                        "const": "SchengenAreaFlight"
+                      },
+                      {
+                        "type": "string",
+                        "const": "airportBoatLink"
+                      },
+                      {
+                        "type": "string",
+                        "const": "airportLinkBus"
+                      },
+                      {
+                        "type": "string",
+                        "const": "airportLinkRail"
+                      },
+                      {
+                        "type": "string",
+                        "const": "airshipService"
+                      },
+                      {
+                        "type": "string",
+                        "const": "allFunicularServices"
+                      },
+                      {
+                        "type": "string",
+                        "const": "allHireVehicles"
+                      },
+                      {
+                        "type": "string",
+                        "const": "allTaxiServices"
+                      },
+                      {
+                        "type": "string",
+                        "const": "bikeTaxi"
+                      },
+                      {
+                        "type": "string",
+                        "const": "blackCab"
+                      },
+                      {
+                        "type": "string",
+                        "const": "cableCar"
+                      },
+                      {
+                        "type": "string",
+                        "const": "cableFerry"
+                      },
+                      {
+                        "type": "string",
+                        "const": "canalBarge"
+                      },
+                      {
+                        "type": "string",
+                        "const": "carTransportRailService"
+                      },
+                      {
+                        "type": "string",
+                        "const": "chairLift"
+                      },
+                      {
+                        "type": "string",
+                        "const": "charterTaxi"
+                      },
+                      {
+                        "type": "string",
+                        "const": "cityTram"
+                      },
+                      {
+                        "type": "string",
+                        "const": "communalTaxi"
+                      },
+                      {
+                        "type": "string",
+                        "const": "commuterCoach"
+                      },
+                      {
+                        "type": "string",
+                        "const": "crossCountryRail"
+                      },
+                      {
+                        "type": "string",
+                        "const": "dedicatedLaneBus"
+                      },
+                      {
+                        "type": "string",
+                        "const": "demandAndResponseBus"
+                      },
+                      {
+                        "type": "string",
+                        "const": "domesticCharterFlight"
+                      },
+                      {
+                        "type": "string",
+                        "const": "domesticFlight"
+                      },
+                      {
+                        "type": "string",
+                        "const": "domesticScheduledFlight"
+                      },
+                      {
+                        "type": "string",
+                        "const": "dragLift"
+                      },
+                      {
+                        "type": "string",
+                        "const": "expressBus"
+                      },
+                      {
+                        "type": "string",
+                        "const": "funicular"
+                      },
+                      {
+                        "type": "string",
+                        "const": "helicopterService"
+                      },
+                      {
+                        "type": "string",
+                        "const": "highFrequencyBus"
+                      },
+                      {
+                        "type": "string",
+                        "const": "highSpeedPassengerService"
+                      },
+                      {
+                        "type": "string",
+                        "const": "highSpeedRail"
+                      },
+                      {
+                        "type": "string",
+                        "const": "highSpeedVehicleService"
+                      },
+                      {
+                        "type": "string",
+                        "const": "hireCar"
+                      },
+                      {
+                        "type": "string",
+                        "const": "hireCycle"
+                      },
+                      {
+                        "type": "string",
+                        "const": "hireMotorbike"
+                      },
+                      {
+                        "type": "string",
+                        "const": "hireVan"
+                      },
+                      {
+                        "type": "string",
+                        "const": "intercontinentalCharterFlight"
+                      },
+                      {
+                        "type": "string",
+                        "const": "intercontinentalFlight"
+                      },
+                      {
+                        "type": "string",
+                        "const": "international"
+                      },
+                      {
+                        "type": "string",
+                        "const": "internationalCarFerry"
+                      },
+                      {
+                        "type": "string",
+                        "const": "internationalCharterFlight"
+                      },
+                      {
+                        "type": "string",
+                        "const": "internationalCoach"
+                      },
+                      {
+                        "type": "string",
+                        "const": "internationalFlight"
+                      },
+                      {
+                        "type": "string",
+                        "const": "internationalPassengerFerry"
+                      },
+                      {
+                        "type": "string",
+                        "const": "interregionalRail"
+                      },
+                      {
+                        "type": "string",
+                        "const": "lift"
+                      },
+                      {
+                        "type": "string",
+                        "const": "local"
+                      },
+                      {
+                        "type": "string",
+                        "const": "localBus"
+                      },
+                      {
+                        "type": "string",
+                        "const": "localCarFerry"
+                      },
+                      {
+                        "type": "string",
+                        "const": "localPassengerFerry"
+                      },
+                      {
+                        "type": "string",
+                        "const": "localTram"
+                      },
+                      {
+                        "type": "string",
+                        "const": "longDistance"
+                      },
+                      {
+                        "type": "string",
+                        "const": "metro"
+                      },
+                      {
+                        "type": "string",
+                        "const": "miniCab"
+                      },
+                      {
+                        "type": "string",
+                        "const": "mobilityBus"
+                      },
+                      {
+                        "type": "string",
+                        "const": "mobilityBusForRegisteredDisabled"
+                      },
+                      {
+                        "type": "string",
+                        "const": "nationalCarFerry"
+                      },
+                      {
+                        "type": "string",
+                        "const": "nationalCoach"
+                      },
+                      {
+                        "type": "string",
+                        "const": "nationalPassengerFerry"
+                      },
+                      {
+                        "type": "string",
+                        "const": "nightBus"
+                      },
+                      {
+                        "type": "string",
+                        "const": "nightRail"
+                      },
+                      {
+                        "type": "string",
+                        "const": "postBoat"
+                      },
+                      {
+                        "type": "string",
+                        "const": "postBus"
+                      },
+                      {
+                        "type": "string",
+                        "const": "rackAndPinionRailway"
+                      },
+                      {
+                        "type": "string",
+                        "const": "railReplacementBus"
+                      },
+                      {
+                        "type": "string",
+                        "const": "railShuttle"
+                      },
+                      {
+                        "type": "string",
+                        "const": "railTaxi"
+                      },
+                      {
+                        "type": "string",
+                        "const": "regionalBus"
+                      },
+                      {
+                        "type": "string",
+                        "const": "regionalCarFerry"
+                      },
+                      {
+                        "type": "string",
+                        "const": "regionalCoach"
+                      },
+                      {
+                        "type": "string",
+                        "const": "regionalPassengerFerry"
+                      },
+                      {
+                        "type": "string",
+                        "const": "regionalRail"
+                      },
+                      {
+                        "type": "string",
+                        "const": "regionalTram"
+                      },
+                      {
+                        "type": "string",
+                        "const": "replacementRailService"
+                      },
+                      {
+                        "type": "string",
+                        "const": "riverBus"
+                      },
+                      {
+                        "type": "string",
+                        "const": "roadFerryLink"
+                      },
+                      {
+                        "type": "string",
+                        "const": "roundTripCharterFlight"
+                      },
+                      {
+                        "type": "string",
+                        "const": "scheduledFerry"
+                      },
+                      {
+                        "type": "string",
+                        "const": "schoolAndPublicServiceBus"
+                      },
+                      {
+                        "type": "string",
+                        "const": "schoolBoat"
+                      },
+                      {
+                        "type": "string",
+                        "const": "schoolBus"
+                      },
+                      {
+                        "type": "string",
+                        "const": "schoolCoach"
+                      },
+                      {
+                        "type": "string",
+                        "const": "shortHaulInternationalFlight"
+                      },
+                      {
+                        "type": "string",
+                        "const": "shuttleBus"
+                      },
+                      {
+                        "type": "string",
+                        "const": "shuttleCoach"
+                      },
+                      {
+                        "type": "string",
+                        "const": "shuttleFerryService"
+                      },
+                      {
+                        "type": "string",
+                        "const": "shuttleFlight"
+                      },
+                      {
+                        "type": "string",
+                        "const": "shuttleTram"
+                      },
+                      {
+                        "type": "string",
+                        "const": "sightseeingBus"
+                      },
+                      {
+                        "type": "string",
+                        "const": "sightseeingCoach"
+                      },
+                      {
+                        "type": "string",
+                        "const": "sightseeingFlight"
+                      },
+                      {
+                        "type": "string",
+                        "const": "sightseeingService"
+                      },
+                      {
+                        "type": "string",
+                        "const": "sightseeingTram"
+                      },
+                      {
+                        "type": "string",
+                        "const": "sleeperRailService"
+                      },
+                      {
+                        "type": "string",
+                        "const": "specialCoach"
+                      },
+                      {
+                        "type": "string",
+                        "const": "specialNeedsBus"
+                      },
+                      {
+                        "type": "string",
+                        "const": "specialTrain"
+                      },
+                      {
+                        "type": "string",
+                        "const": "streetCableCar"
+                      },
+                      {
+                        "type": "string",
+                        "const": "suburbanRailway"
+                      },
+                      {
+                        "type": "string",
+                        "const": "telecabin"
+                      },
+                      {
+                        "type": "string",
+                        "const": "telecabinLink"
+                      },
+                      {
+                        "type": "string",
+                        "const": "touristCoach"
+                      },
+                      {
+                        "type": "string",
+                        "const": "touristRailway"
+                      },
+                      {
+                        "type": "string",
+                        "const": "trainFerry"
+                      },
+                      {
+                        "type": "string",
+                        "const": "trainTram"
+                      },
+                      {
+                        "type": "string",
+                        "const": "tube"
+                      },
+                      {
+                        "type": "string",
+                        "const": "undefined"
+                      },
+                      {
+                        "type": "string",
+                        "const": "undefinedFunicular"
+                      },
+                      {
+                        "type": "string",
+                        "const": "unknown"
+                      },
+                      {
+                        "type": "string",
+                        "const": "urbanRailway"
+                      },
+                      {
+                        "type": "string",
+                        "const": "waterTaxi"
+                      }
+                    ]
+                  }
+                }
+              },
+              "required": ["transportMode"],
+              "additionalProperties": false
+            }
+          },
+          "selectedAsDefault": {
+            "type": "boolean"
+          }
+        },
+        "required": ["id", "icon", "text", "modes", "selectedAsDefault"],
+        "additionalProperties": false
+      }
+    },
+    "flexibleTransport": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "title": {
+          "minItems": 1,
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "lang": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": ["lang", "value"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "language": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          }
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "string",
+              "const": "beta"
+            },
+            {
+              "type": "string",
+              "const": "new"
+            }
+          ]
+        },
+        "description": {
+          "minItems": 1,
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "lang": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": ["lang", "value"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "language": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
           }
         }
       },
+      "required": ["id", "title", "description"],
       "additionalProperties": false
+    },
+    "travelSearchPreferences": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "anyOf": [
+              {
+                "type": "string",
+                "const": "transferSlack"
+              },
+              {
+                "type": "string",
+                "const": "transferPenalty"
+              },
+              {
+                "type": "string",
+                "const": "waitReluctance"
+              },
+              {
+                "type": "string",
+                "const": "walkReluctance"
+              },
+              {
+                "type": "string",
+                "const": "walkSpeed"
+              }
+            ]
+          },
+          "title": {
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "lang": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["lang", "value"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "language": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
+          },
+          "options": {
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "text": {
+                  "minItems": 1,
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "lang": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["lang", "value"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "language": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
+                "value": {
+                  "type": "number",
+                  "minimum": 0
+                }
+              },
+              "required": ["id", "text", "value"],
+              "additionalProperties": false
+            }
+          },
+          "defaultOption": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": ["type", "title", "options", "defaultOption"],
+        "additionalProperties": false
+      }
     }
   },
-  "$schema": "http://json-schema.org/draft-07/schema#"
+  "additionalProperties": false
 }

--- a/schema-definitions/urls.json
+++ b/schema-definitions/urls.json
@@ -1,95 +1,552 @@
 {
-  "$ref": "#/definitions/ConfigurableLinks",
-  "definitions": {
-    "LanguageAndTextType": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "lang": {
-              "type": "string"
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ConfigurableLinks",
+  "type": "object",
+  "properties": {
+    "ticketingInfo": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "lang": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
             },
-            "value": {
-              "type": "string"
-            }
+            "required": ["lang", "value"],
+            "additionalProperties": false
           },
-          "required": ["lang", "value"],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "language": {
-              "type": "string"
+          {
+            "type": "object",
+            "properties": {
+              "language": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
             },
-            "value": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
-    "ConfigurableLinks": {
-      "type": "object",
-      "properties": {
-        "ticketingInfo": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/LanguageAndTextType"
+            "additionalProperties": false
           }
-        },
-        "termsInfo": {
-          "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
-        },
-        "inspectionInfo": {
-          "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
-        },
-        "refundInfo": {
-          "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
-        },
-        "flexTransportInfo": {
-          "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
-        },
-        "dataSharingInfo": {
-          "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
-        },
-        "appA11yStatement": {
-          "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
-        },
-        "iosStoreListing": {
-          "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
-        },
-        "androidStoreListing": {
-          "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
-        },
-        "externalRealtimeMap": {
-          "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
-        },
-        "tileServerBaseUrl": {
-          "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
-        },
-        "mapboxSpriteUrl": {
-          "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
-        },
-        "mobilityTermsUrl": {
-          "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
-        },
-        "contactFormUrl": {
-          "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
-        },
-        "lostAndFoundUrl": {
-          "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
-        },
-        "frequentlyAskedQuestionsUrl": {
-          "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
-        },
-        "sparReadMoreUrl": {
-          "$ref": "#/definitions/ConfigurableLinks/properties/ticketingInfo"
-        }
-      },
-      "additionalProperties": false
+        ]
+      }
+    },
+    "termsInfo": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "lang": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": ["lang", "value"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "language": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "inspectionInfo": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "lang": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": ["lang", "value"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "language": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "refundInfo": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "lang": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": ["lang", "value"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "language": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "flexTransportInfo": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "lang": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": ["lang", "value"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "language": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "dataSharingInfo": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "lang": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": ["lang", "value"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "language": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "appA11yStatement": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "lang": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": ["lang", "value"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "language": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "iosStoreListing": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "lang": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": ["lang", "value"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "language": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "androidStoreListing": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "lang": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": ["lang", "value"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "language": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "externalRealtimeMap": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "lang": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": ["lang", "value"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "language": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "tileServerBaseUrl": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "lang": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": ["lang", "value"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "language": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "mapboxSpriteUrl": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "lang": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": ["lang", "value"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "language": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "mobilityTermsUrl": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "lang": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": ["lang", "value"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "language": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "contactFormUrl": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "lang": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": ["lang", "value"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "language": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "lostAndFoundUrl": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "lang": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": ["lang", "value"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "language": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "frequentlyAskedQuestionsUrl": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "lang": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": ["lang", "value"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "language": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "sparReadMoreUrl": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "lang": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": ["lang", "value"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "language": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
     }
   },
-  "$schema": "http://json-schema.org/draft-07/schema#"
+  "additionalProperties": false
 }

--- a/src/reference-data.ts
+++ b/src/reference-data.ts
@@ -3,12 +3,16 @@ import {LanguageAndTextType, LanguageAndTextTypeArray} from './common';
 import {ZoneSelectionMode} from './fare-product-type';
 import {nullishToOptional} from './utils/nullish-to-optional';
 
+/**
+ * zod transforms cant be represented in exported json schema files.
+ * opt is a helper to generate with or without transforms.
+ */
 const opt = <T extends z.ZodTypeAny>(base: T, includeTransform: boolean) =>
   includeTransform
     ? base.nullish().transform(nullishToOptional).optional()
     : base.optional();
 
-const getPreassignedFareProduct = (includeTransform = false) =>
+const getPreassignedFareProduct = (includeTransform: boolean) =>
   z.object({
     id: z.string(),
     version: z.string(),

--- a/src/reference-data.ts
+++ b/src/reference-data.ts
@@ -45,7 +45,7 @@ import {nullishToOptional} from './utils/nullish-to-optional';
 
 const opt = <T extends z.ZodTypeAny>(base: T, includeTransform: boolean) =>
   includeTransform
-    ? base.nullish().transform(nullishToOptional)
+    ? base.nullish().transform(nullishToOptional).optional()
     : base.optional();
 
 const getPreassignedFareProduct = (includeTransform = false) =>

--- a/src/reference-data.ts
+++ b/src/reference-data.ts
@@ -103,26 +103,23 @@ export const UserProfile = z.object({
   emoji: z.string().optional(),
 });
 
-const getReferenceData = (includeTransform: boolean) =>
-  z.object({
-    preassignedFareProducts_v2: z.array(PreassignedFareProduct),
-    fareZones: z.array(FareZone),
-    userProfiles: z.array(UserProfile),
-    cityZones: z.array(CityZone).optional(),
-    carPoolingZones: z.array(CarPoolingZone).optional(),
+export const ReferenceData = z.object({
+  preassignedFareProducts_v2: z.array(PreassignedFareProduct),
+  fareZones: z.array(FareZone),
+  userProfiles: z.array(UserProfile),
+  cityZones: z.array(CityZone).optional(),
+  carPoolingZones: z.array(CarPoolingZone).optional(),
 
-    /**
-     * @deprecated Use preassignedFareProducts_v2 instead
-     */
-    preassignedFareProducts: z.any(),
+  /**
+   * @deprecated Use preassignedFareProducts_v2 instead
+   */
+  preassignedFareProducts: z.any(),
 
-    /**
-     * @deprecated Use fareZones instead
-     */
-    tariffZones: z.array(TariffZone),
-  });
-export const ReferenceData = getReferenceData(true);
-export const ReferenceDataJsonSchema = getReferenceData(false);
+  /**
+   * @deprecated Use fareZones instead
+   */
+  tariffZones: z.array(TariffZone),
+});
 
 export type PreassignedFareProduct = z.infer<typeof PreassignedFareProduct>;
 

--- a/src/reference-data.ts
+++ b/src/reference-data.ts
@@ -3,46 +3,6 @@ import {LanguageAndTextType, LanguageAndTextTypeArray} from './common';
 import {ZoneSelectionMode} from './fare-product-type';
 import {nullishToOptional} from './utils/nullish-to-optional';
 
-// export const PreassignedFareProduct = z.object({
-//   id: z.string(),
-//   version: z.string(),
-//   type: z.string(),
-//   distributionChannel: z.array(z.string()),
-//   name: LanguageAndTextType,
-//   limitations: z.object({
-//     userProfileRefs: z.array(z.string()),
-//     appVersionMin: z.string().nullish().transform(nullishToOptional),
-//     appVersionMax: z.string().nullish().transform(nullishToOptional),
-//     fareZoneRefs: z.array(z.string()).nullish().transform(nullishToOptional),
-
-//     /**
-//      * @deprecated use fareZoneRefs instead
-//      */
-//     tariffZoneRefs: z.array(z.string()).nullish().transform(nullishToOptional),
-//   }),
-//   durationDays: z.number().nullish().transform(nullishToOptional),
-//   isApplicableOnSingleZoneOnly: z
-//     .boolean()
-//     .nullish()
-//     .transform(nullishToOptional),
-//   isBookingEnabled: z.boolean().nullish().transform(nullishToOptional),
-//   isEnabledForTripSearchOffer: z
-//     .boolean()
-//     .nullish()
-//     .transform(nullishToOptional),
-//   isDefault: z.boolean().nullish().transform(nullishToOptional),
-//   alternativeNames:
-//     LanguageAndTextTypeArray.nullish().transform(nullishToOptional),
-//   zoneSelectionMode: ZoneSelectionMode.nullish().transform(nullishToOptional),
-//   description: LanguageAndTextTypeArray.nullish().transform(nullishToOptional),
-//   productDescription:
-//     LanguageAndTextTypeArray.nullish().transform(nullishToOptional),
-//   productAliasId: z.string().nullish().transform(nullishToOptional),
-//   productAlias: LanguageAndTextTypeArray.nullish().transform(nullishToOptional),
-//   warningMessage:
-//     LanguageAndTextTypeArray.nullish().transform(nullishToOptional),
-// });
-
 const opt = <T extends z.ZodTypeAny>(base: T, includeTransform: boolean) =>
   includeTransform
     ? base.nullish().transform(nullishToOptional).optional()

--- a/src/reference-data.ts
+++ b/src/reference-data.ts
@@ -1,47 +1,86 @@
-import {z} from 'zod';
+import {z} from 'zod/v4';
 import {LanguageAndTextType, LanguageAndTextTypeArray} from './common';
 import {ZoneSelectionMode} from './fare-product-type';
 import {nullishToOptional} from './utils/nullish-to-optional';
 
-export const PreassignedFareProduct = z.object({
-  id: z.string(),
-  version: z.string(),
-  type: z.string(),
-  distributionChannel: z.array(z.string()),
-  name: LanguageAndTextType,
-  limitations: z.object({
-    userProfileRefs: z.array(z.string()),
-    appVersionMin: z.string().nullish().transform(nullishToOptional),
-    appVersionMax: z.string().nullish().transform(nullishToOptional),
-    fareZoneRefs: z.array(z.string()).nullish().transform(nullishToOptional),
+// export const PreassignedFareProduct = z.object({
+//   id: z.string(),
+//   version: z.string(),
+//   type: z.string(),
+//   distributionChannel: z.array(z.string()),
+//   name: LanguageAndTextType,
+//   limitations: z.object({
+//     userProfileRefs: z.array(z.string()),
+//     appVersionMin: z.string().nullish().transform(nullishToOptional),
+//     appVersionMax: z.string().nullish().transform(nullishToOptional),
+//     fareZoneRefs: z.array(z.string()).nullish().transform(nullishToOptional),
 
-    /**
-     * @deprecated use fareZoneRefs instead
-     */
-    tariffZoneRefs: z.array(z.string()).nullish().transform(nullishToOptional),
-  }),
-  durationDays: z.number().nullish().transform(nullishToOptional),
-  isApplicableOnSingleZoneOnly: z
-    .boolean()
-    .nullish()
-    .transform(nullishToOptional),
-  isBookingEnabled: z.boolean().nullish().transform(nullishToOptional),
-  isEnabledForTripSearchOffer: z
-    .boolean()
-    .nullish()
-    .transform(nullishToOptional),
-  isDefault: z.boolean().nullish().transform(nullishToOptional),
-  alternativeNames:
-    LanguageAndTextTypeArray.nullish().transform(nullishToOptional),
-  zoneSelectionMode: ZoneSelectionMode.nullish().transform(nullishToOptional),
-  description: LanguageAndTextTypeArray.nullish().transform(nullishToOptional),
-  productDescription:
-    LanguageAndTextTypeArray.nullish().transform(nullishToOptional),
-  productAliasId: z.string().nullish().transform(nullishToOptional),
-  productAlias: LanguageAndTextTypeArray.nullish().transform(nullishToOptional),
-  warningMessage:
-    LanguageAndTextTypeArray.nullish().transform(nullishToOptional),
-});
+//     /**
+//      * @deprecated use fareZoneRefs instead
+//      */
+//     tariffZoneRefs: z.array(z.string()).nullish().transform(nullishToOptional),
+//   }),
+//   durationDays: z.number().nullish().transform(nullishToOptional),
+//   isApplicableOnSingleZoneOnly: z
+//     .boolean()
+//     .nullish()
+//     .transform(nullishToOptional),
+//   isBookingEnabled: z.boolean().nullish().transform(nullishToOptional),
+//   isEnabledForTripSearchOffer: z
+//     .boolean()
+//     .nullish()
+//     .transform(nullishToOptional),
+//   isDefault: z.boolean().nullish().transform(nullishToOptional),
+//   alternativeNames:
+//     LanguageAndTextTypeArray.nullish().transform(nullishToOptional),
+//   zoneSelectionMode: ZoneSelectionMode.nullish().transform(nullishToOptional),
+//   description: LanguageAndTextTypeArray.nullish().transform(nullishToOptional),
+//   productDescription:
+//     LanguageAndTextTypeArray.nullish().transform(nullishToOptional),
+//   productAliasId: z.string().nullish().transform(nullishToOptional),
+//   productAlias: LanguageAndTextTypeArray.nullish().transform(nullishToOptional),
+//   warningMessage:
+//     LanguageAndTextTypeArray.nullish().transform(nullishToOptional),
+// });
+
+const opt = <T extends z.ZodTypeAny>(base: T, includeTransform: boolean) =>
+  includeTransform
+    ? base.nullish().transform(nullishToOptional)
+    : base.optional();
+
+const getPreassignedFareProduct = (includeTransform = false) =>
+  z.object({
+    id: z.string(),
+    version: z.string(),
+    type: z.string(),
+    distributionChannel: z.array(z.string()),
+    name: LanguageAndTextType,
+    limitations: z.object({
+      userProfileRefs: z.array(z.string()),
+      appVersionMin: opt(z.string(), includeTransform),
+      appVersionMax: opt(z.string(), includeTransform),
+      fareZoneRefs: opt(z.array(z.string()), includeTransform),
+
+      /**
+       * @deprecated use fareZoneRefs instead
+       */
+      tariffZoneRefs: opt(z.array(z.string()), includeTransform),
+    }),
+    durationDays: opt(z.number(), includeTransform),
+    isApplicableOnSingleZoneOnly: opt(z.boolean(), includeTransform),
+    isBookingEnabled: opt(z.boolean(), includeTransform),
+    isEnabledForTripSearchOffer: opt(z.boolean(), includeTransform),
+    isDefault: opt(z.boolean(), includeTransform),
+    alternativeNames: opt(LanguageAndTextTypeArray, includeTransform),
+    zoneSelectionMode: opt(ZoneSelectionMode, includeTransform),
+    description: opt(LanguageAndTextTypeArray, includeTransform),
+    productDescription: opt(LanguageAndTextTypeArray, includeTransform),
+    productAliasId: opt(z.string(), includeTransform),
+    productAlias: opt(LanguageAndTextTypeArray, includeTransform),
+    warningMessage: opt(LanguageAndTextTypeArray, includeTransform),
+  });
+
+export const PreassignedFareProduct = getPreassignedFareProduct(true);
 
 /**
  * @deprecated
@@ -109,23 +148,28 @@ export const UserProfile = z.object({
   emoji: z.string().optional(),
 });
 
-export const ReferenceData = z.object({
-  preassignedFareProducts_v2: z.array(PreassignedFareProduct),
-  fareZones: z.array(FareZone),
-  userProfiles: z.array(UserProfile),
-  cityZones: z.array(CityZone).optional(),
-  carPoolingZones: z.array(CarPoolingZone).optional(),
+const getReferenceData = (includeTransform: boolean) =>
+  z.object({
+    preassignedFareProducts_v2: z.array(
+      getPreassignedFareProduct(includeTransform),
+    ),
+    fareZones: z.array(FareZone),
+    userProfiles: z.array(UserProfile),
+    cityZones: z.array(CityZone).optional(),
+    carPoolingZones: z.array(CarPoolingZone).optional(),
 
-  /**
-   * @deprecated Use preassignedFareProducts_v2 instead
-   */
-  preassignedFareProducts: z.any(),
+    /**
+     * @deprecated Use preassignedFareProducts_v2 instead
+     */
+    preassignedFareProducts: z.any(),
 
-  /**
-   * @deprecated Use fareZones instead
-   */
-  tariffZones: z.array(TariffZone),
-});
+    /**
+     * @deprecated Use fareZones instead
+     */
+    tariffZones: z.array(TariffZone),
+  });
+export const ReferenceData = getReferenceData(true);
+export const ReferenceDataJsonSchema = getReferenceData(false);
 
 export type PreassignedFareProduct = z.infer<typeof PreassignedFareProduct>;
 

--- a/src/reference-data.ts
+++ b/src/reference-data.ts
@@ -3,48 +3,39 @@ import {LanguageAndTextType, LanguageAndTextTypeArray} from './common';
 import {ZoneSelectionMode} from './fare-product-type';
 import {nullishToOptional} from './utils/nullish-to-optional';
 
-/**
- * zod transforms cant be represented in exported json schema files.
- * opt is a helper to generate with or without transforms.
- */
-const opt = <T extends z.ZodTypeAny>(base: T, includeTransform: boolean) =>
-  includeTransform
-    ? base.nullish().transform(nullishToOptional).optional()
-    : base.optional();
+const optionalNullish = <T extends z.ZodTypeAny>(base: T) =>
+  base.nullish().transform(nullishToOptional).optional();
 
-const getPreassignedFareProduct = (includeTransform: boolean) =>
-  z.object({
-    id: z.string(),
-    version: z.string(),
-    type: z.string(),
-    distributionChannel: z.array(z.string()),
-    name: LanguageAndTextType,
-    limitations: z.object({
-      userProfileRefs: z.array(z.string()),
-      appVersionMin: opt(z.string(), includeTransform),
-      appVersionMax: opt(z.string(), includeTransform),
-      fareZoneRefs: opt(z.array(z.string()), includeTransform),
+export const PreassignedFareProduct = z.object({
+  id: z.string(),
+  version: z.string(),
+  type: z.string(),
+  distributionChannel: z.array(z.string()),
+  name: LanguageAndTextType,
+  limitations: z.object({
+    userProfileRefs: z.array(z.string()),
+    appVersionMin: optionalNullish(z.string()),
+    appVersionMax: optionalNullish(z.string()),
+    fareZoneRefs: optionalNullish(z.array(z.string())),
 
-      /**
-       * @deprecated use fareZoneRefs instead
-       */
-      tariffZoneRefs: opt(z.array(z.string()), includeTransform),
-    }),
-    durationDays: opt(z.number(), includeTransform),
-    isApplicableOnSingleZoneOnly: opt(z.boolean(), includeTransform),
-    isBookingEnabled: opt(z.boolean(), includeTransform),
-    isEnabledForTripSearchOffer: opt(z.boolean(), includeTransform),
-    isDefault: opt(z.boolean(), includeTransform),
-    alternativeNames: opt(LanguageAndTextTypeArray, includeTransform),
-    zoneSelectionMode: opt(ZoneSelectionMode, includeTransform),
-    description: opt(LanguageAndTextTypeArray, includeTransform),
-    productDescription: opt(LanguageAndTextTypeArray, includeTransform),
-    productAliasId: opt(z.string(), includeTransform),
-    productAlias: opt(LanguageAndTextTypeArray, includeTransform),
-    warningMessage: opt(LanguageAndTextTypeArray, includeTransform),
-  });
-
-export const PreassignedFareProduct = getPreassignedFareProduct(true);
+    /**
+     * @deprecated use fareZoneRefs instead
+     */
+    tariffZoneRefs: optionalNullish(z.array(z.string())),
+  }),
+  durationDays: optionalNullish(z.number()),
+  isApplicableOnSingleZoneOnly: optionalNullish(z.boolean()),
+  isBookingEnabled: optionalNullish(z.boolean()),
+  isEnabledForTripSearchOffer: optionalNullish(z.boolean()),
+  isDefault: optionalNullish(z.boolean()),
+  alternativeNames: optionalNullish(LanguageAndTextTypeArray),
+  zoneSelectionMode: optionalNullish(ZoneSelectionMode),
+  description: optionalNullish(LanguageAndTextTypeArray),
+  productDescription: optionalNullish(LanguageAndTextTypeArray),
+  productAliasId: optionalNullish(z.string()),
+  productAlias: optionalNullish(LanguageAndTextTypeArray),
+  warningMessage: optionalNullish(LanguageAndTextTypeArray),
+});
 
 /**
  * @deprecated
@@ -114,9 +105,7 @@ export const UserProfile = z.object({
 
 const getReferenceData = (includeTransform: boolean) =>
   z.object({
-    preassignedFareProducts_v2: z.array(
-      getPreassignedFareProduct(includeTransform),
-    ),
+    preassignedFareProducts_v2: z.array(PreassignedFareProduct),
     fareZones: z.array(FareZone),
     userProfiles: z.array(UserProfile),
     cityZones: z.array(CityZone).optional(),

--- a/src/tools/specifications-types.ts
+++ b/src/tools/specifications-types.ts
@@ -1,25 +1,9 @@
 import {z} from 'zod';
-import {
-  LanguageAndTextType,
-  LanguageAndTextTypeArray,
-  TransportModeType,
-  TransportSubmodeType,
-} from '../common';
-import {
-  FareProductGroup,
-  FareProductTypeConfig,
-  FareProductTypeConfigSettings,
-  ProductTypeTransportModes,
-} from '../fare-product-type';
-import {
-  TravelSearchFilters,
-  TravelSearchTransportModeIcon,
-  TravelSearchTransportModes,
-} from '../travel-search-filters';
+import {FareProductGroup, FareProductTypeConfig} from '../fare-product-type';
+import {TravelSearchFilters} from '../travel-search-filters';
 import {
   BonusProduct,
   BonusTexts,
-  FormFactor,
   MobilityOperator,
   OperatorBenefitId,
   BonusSource,
@@ -113,6 +97,6 @@ export const jsonSchemas = {
   harborConnectionOverrides: z.toJSONSchema(HarborConnectionOverrides),
   notificationConfig: z.toJSONSchema(NotificationConfig),
   consents: z.toJSONSchema(Consents),
-  referenceData: z.toJSONSchema(ReferenceDataJsonSchema),
+  referenceData: z.toJSONSchema(ReferenceDataJsonSchema, {io: 'input'}),
   stopSignalButtonConfig: z.toJSONSchema(StopSignalButtonConfig),
 } satisfies Record<SchemaNames, unknown>;

--- a/src/tools/specifications-types.ts
+++ b/src/tools/specifications-types.ts
@@ -1,5 +1,4 @@
 import {z} from 'zod';
-import zodToJsonSchema, {JsonSchema7Type} from 'zod-to-json-schema';
 import {
   LanguageAndTextType,
   LanguageAndTextTypeArray,
@@ -33,7 +32,7 @@ import {NotificationConfig} from '../notification-config';
 import {Consents} from '../consents';
 import {PaymentTypes} from '../payment-types';
 import {Other} from '../other';
-import {ReferenceData} from '../reference-data';
+import {ReferenceDataJsonSchema} from '../reference-data';
 import {StopSignalButtonConfig} from '../stop-signal-button-config';
 
 // All supported specifications
@@ -73,68 +72,47 @@ export const schemaTypes = {
   harborConnectionOverrides: HarborConnectionOverrides,
   notificationConfig: NotificationConfig,
   consents: Consents,
-  referenceData: ReferenceData,
+  referenceData: ReferenceDataJsonSchema,
   stopSignalButtonConfig: StopSignalButtonConfig,
 };
 
 // All correctly supported schema types as JSON Schema data structures
 export const jsonSchemas = {
-  fareProductTypeConfigs: zodToJsonSchema(
-    z.object({
-      fareProductTypeConfigs: z.array(FareProductTypeConfig),
-      fareProductGroups: z.array(FareProductGroup).optional(),
-    }),
-    {
-      name: 'FareProductConfiguration',
-      definitions: {
-        LanguageAndTextType,
-        ProductTypeTransportModes,
-        FareProductTypeConfigSettings,
-        FareProductTypeConfig,
-        TransportModeType,
-        TransportSubmodeType,
-      },
-    },
+  fareProductTypeConfigs: z.toJSONSchema(
+    z
+      .object({
+        fareProductTypeConfigs: z.array(FareProductTypeConfig),
+        fareProductGroups: z.array(FareProductGroup).optional(),
+      })
+      .meta({title: 'FareProductConfiguration'}),
   ),
-  mobility: zodToJsonSchema(
-    z.object({
-      operators: z.array(MobilityOperator),
-      scooterFaqs: z.array(ScooterFaq).optional(),
-      scooterConsentLines: z.array(ScooterConsentLine).optional(),
-      benefitIdsRequiringValueCode: z.array(OperatorBenefitId).optional(),
-      bonusProducts: z.array(BonusProduct).optional(),
-      bonusTexts: BonusTexts.optional(),
-      bonusSources: z.array(BonusSource).optional(),
-    }),
-    {
-      name: 'MobilityOperator',
-      definitions: {
-        FormFactor,
-        OperatorBenefitId,
-      },
-    },
+
+  mobility: z.toJSONSchema(
+    z
+      .object({
+        operators: z.array(MobilityOperator),
+        scooterFaqs: z.array(ScooterFaq).optional(),
+        scooterConsentLines: z.array(ScooterConsentLine).optional(),
+        benefitIdsRequiringValueCode: z.array(OperatorBenefitId).optional(),
+        bonusProducts: z.array(BonusProduct).optional(),
+        bonusTexts: BonusTexts.optional(),
+        bonusSources: z.array(BonusSource).optional(),
+      })
+      .meta({title: 'MobilityOperator'}),
   ),
-  other: zodToJsonSchema(Other),
-  paymentTypes: zodToJsonSchema(PaymentTypes),
-  travelSearchFilters: zodToJsonSchema(TravelSearchFilters, {
-    name: 'TravelSearchFilters',
-    definitions: {
-      LanguageAndTextTypeArray,
-      TravelSearchTransportModes,
-      TravelSearchTransportModeIcon,
-      TransportModeType,
-      TransportSubmodeType,
-    },
-  }),
-  urls: zodToJsonSchema(ConfigurableLinks, {
-    name: 'ConfigurableLinks',
-    definitions: {
-      LanguageAndTextType,
-    },
-  }),
-  harborConnectionOverrides: zodToJsonSchema(HarborConnectionOverrides),
-  notificationConfig: zodToJsonSchema(NotificationConfig),
-  consents: zodToJsonSchema(Consents),
-  referenceData: zodToJsonSchema(ReferenceData),
-  stopSignalButtonConfig: zodToJsonSchema(StopSignalButtonConfig),
-} satisfies Record<SchemaNames, JsonSchema7Type | undefined>;
+
+  other: z.toJSONSchema(Other),
+  paymentTypes: z.toJSONSchema(PaymentTypes),
+
+  travelSearchFilters: z.toJSONSchema(
+    TravelSearchFilters.meta({title: 'TravelSearchFilters'}),
+  ),
+
+  urls: z.toJSONSchema(ConfigurableLinks.meta({title: 'ConfigurableLinks'})),
+
+  harborConnectionOverrides: z.toJSONSchema(HarborConnectionOverrides),
+  notificationConfig: z.toJSONSchema(NotificationConfig),
+  consents: z.toJSONSchema(Consents),
+  referenceData: z.toJSONSchema(ReferenceDataJsonSchema),
+  stopSignalButtonConfig: z.toJSONSchema(StopSignalButtonConfig),
+} satisfies Record<SchemaNames, unknown>;

--- a/src/tools/specifications-types.ts
+++ b/src/tools/specifications-types.ts
@@ -16,7 +16,7 @@ import {NotificationConfig} from '../notification-config';
 import {Consents} from '../consents';
 import {PaymentTypes} from '../payment-types';
 import {Other} from '../other';
-import {ReferenceDataJsonSchema} from '../reference-data';
+import {ReferenceData} from '../reference-data';
 import {StopSignalButtonConfig} from '../stop-signal-button-config';
 
 // All supported specifications
@@ -56,7 +56,7 @@ export const schemaTypes = {
   harborConnectionOverrides: HarborConnectionOverrides,
   notificationConfig: NotificationConfig,
   consents: Consents,
-  referenceData: ReferenceDataJsonSchema,
+  referenceData: ReferenceData,
   stopSignalButtonConfig: StopSignalButtonConfig,
 };
 
@@ -97,6 +97,6 @@ export const jsonSchemas = {
   harborConnectionOverrides: z.toJSONSchema(HarborConnectionOverrides),
   notificationConfig: z.toJSONSchema(NotificationConfig),
   consents: z.toJSONSchema(Consents),
-  referenceData: z.toJSONSchema(ReferenceDataJsonSchema, {io: 'input'}),
+  referenceData: z.toJSONSchema(ReferenceData, {io: 'input'}),
   stopSignalButtonConfig: z.toJSONSchema(StopSignalButtonConfig),
 } satisfies Record<SchemaNames, unknown>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/recommended/tsconfig.json",
+  "extends": "@tsconfig/node22/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "declaration": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -203,10 +203,10 @@
     "@swc/core-win32-ia32-msvc" "1.3.44"
     "@swc/core-win32-x64-msvc" "1.3.44"
 
-"@tsconfig/recommended@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@tsconfig/recommended/-/recommended-1.0.2.tgz#1e198237225933e319718f082e78366e9f159d71"
-  integrity sha512-dbHBtbWBOjq0/otpopAE02NT2Cm05Qe2JsEKeCf/wjSYbI2hz8nCqnpnOJWHATgjDz4fd3dchs3Wy1gQGjfN6w==
+"@tsconfig/node22@^22.0.2":
+  version "22.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node22/-/node22-22.0.2.tgz#1e04e2c5cc946dac787d69bb502462a851ae51b6"
+  integrity sha512-Kmwj4u8sDRDrMYRoN9FDEcXD8UpBSaPQQ24Gz+Gamqfm7xxn+GBR7ge/Z7pK8OXNGyUzbSwJj+TH6B+DS/epyA==
 
 "@types/chai-subset@^1.3.3":
   version "1.3.3"
@@ -854,10 +854,10 @@ type-detect@^4.0.0, type-detect@^4.0.5:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-typescript@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"
-  integrity sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==
+typescript@^5.9.2:
+  version "5.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.2.tgz#d93450cddec5154a2d5cabe3b8102b83316fb2a6"
+  integrity sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==
 
 ufo@^1.1.1:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -970,12 +970,7 @@ yocto-queue@^1.0.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
 
-zod-to-json-schema@^3.24.5:
-  version "3.24.5"
-  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz#d1095440b147fb7c2093812a53c54df8d5df50a3"
-  integrity sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==
-
-zod@^3.24.4:
-  version "3.24.4"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.24.4.tgz#e2e2cca5faaa012d76e527d0d36622e0a90c315f"
-  integrity sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==
+zod@^4.1.11:
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.1.11.tgz#4aab62f76cfd45e6c6166519ba31b2ea019f75f5"
+  integrity sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==


### PR DESCRIPTION
Upgrading zod and node versions.

Now using built-in json schema export instead of zod-to-json-schema.

JSON exports don't support transforms. This is now explicitly handled by specifying `{io: 'input'}`, which previously was "selected invisible under the hood" by zod-to-json-schema.