### PR TITLE
feat: Limitations rewrite

### DIFF
--- a/schema-definitions/referenceData.json
+++ b/schema-definitions/referenceData.json
@@ -122,7 +122,9 @@
                     "maxCount": {
                       "anyOf": [
                         {
-                          "type": "number"
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 9007199254740991
                         },
                         {
                           "type": "null"
@@ -136,7 +138,9 @@
               "maxCountPerOrder": {
                 "anyOf": [
                   {
-                    "type": "number"
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
                   },
                   {
                     "type": "null"

--- a/schema-definitions/referenceData.json
+++ b/schema-definitions/referenceData.json
@@ -72,27 +72,6 @@
                   }
                 ]
               },
-              "userProfileRefs": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "userProfiles": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "userProfileRef": {
-                      "type": "string"
-                    },
-                    "maxCount": {
-                      "type": "number"
-                    }
-                  },
-                  "required": ["userProfileRef", "maxCount"]
-                }
-              },
               "fareZoneRefs": {
                 "anyOf": [
                   {
@@ -132,7 +111,29 @@
                   }
                 ]
               },
-              "limitPerOrder": {
+              "userProfiles": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "userProfileRef": {
+                      "type": "string"
+                    },
+                    "maxCount": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": ["userProfileRef"]
+                }
+              },
+              "maxCountPerOrder": {
                 "anyOf": [
                   {
                     "type": "number"
@@ -143,7 +144,7 @@
                 ]
               }
             },
-            "required": ["userProfileRefs", "userProfiles"]
+            "required": ["userProfiles"]
           },
           "durationDays": {
             "anyOf": [

--- a/schema-definitions/referenceData.json
+++ b/schema-definitions/referenceData.json
@@ -78,6 +78,21 @@
                   "type": "string"
                 }
               },
+              "userProfiles": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "userProfileRef": {
+                      "type": "string"
+                    },
+                    "maxCount": {
+                      "type": "number"
+                    }
+                  },
+                  "required": ["userProfileRef", "maxCount"]
+                }
+              },
               "fareZoneRefs": {
                 "anyOf": [
                   {
@@ -116,9 +131,19 @@
                     "type": "null"
                   }
                 ]
+              },
+              "limitPerOrder": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               }
             },
-            "required": ["userProfileRefs"]
+            "required": ["userProfileRefs", "userProfiles"]
           },
           "durationDays": {
             "anyOf": [
@@ -981,54 +1006,8 @@
                             "type": "null"
                           }
                         ]
-                      },
-                      "userProfileRefs": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "fareZoneRefs": {
-                        "anyOf": [
-                          {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            }
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      },
-                      "tariffZoneRefs": {
-                        "anyOf": [
-                          {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            }
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      },
-                      "supplementProductRefs": {
-                        "anyOf": [
-                          {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            }
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
                       }
-                    },
-                    "required": ["userProfileRefs"]
+                    }
                   },
                   {
                     "type": "null"
@@ -1203,54 +1182,8 @@
                             "type": "null"
                           }
                         ]
-                      },
-                      "userProfileRefs": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "fareZoneRefs": {
-                        "anyOf": [
-                          {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            }
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      },
-                      "tariffZoneRefs": {
-                        "anyOf": [
-                          {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            }
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      },
-                      "supplementProductRefs": {
-                        "anyOf": [
-                          {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            }
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
                       }
-                    },
-                    "required": ["userProfileRefs"]
+                    }
                   },
                   {
                     "type": "null"

--- a/src/reference-data.ts
+++ b/src/reference-data.ts
@@ -32,10 +32,10 @@ export const PreassignedFareProductLimitations = AppVersionedItemSchema.extend({
   userProfiles: z.array(
     z.object({
       userProfileRef: z.string(),
-      maxCount: optionalNullish(z.number()),
+      maxCount: optionalNullish(z.number().int().nonnegative()),
     }),
   ),
-  maxCountPerOrder: optionalNullish(z.number()),
+  maxCountPerOrder: optionalNullish(z.number().int().nonnegative()),
 });
 
 export const PreassignedFareProduct = z.object({

--- a/src/reference-data.ts
+++ b/src/reference-data.ts
@@ -13,23 +13,29 @@ import {TransportModeType, TransportSubmodeType} from './common';
  * These are only relevant for products, i.e. not supplement products
  */
 export const PreassignedFareProductLimitations = AppVersionedItemSchema.extend({
-  /**
-   * @deprecated use userProfiles instead
-   */
-  userProfileRefs: z.array(z.string()),
-  userProfiles: z.array(
-    z.object({
-      userProfileRef: z.string(),
-      maxCount: z.number(),
-    }),
-  ),
   fareZoneRefs: optionalNullish(z.array(z.string())),
   /**
    * @deprecated use fareZoneRefs instead
    */
   tariffZoneRefs: optionalNullish(z.array(z.string())),
   supplementProductRefs: optionalNullish(z.array(z.string())),
-  limitPerOrder: optionalNullish(z.number()),
+
+  /*
+   * The types below are not intended to be set in Firestore,
+   * but are returned from the v2 endpoint of the product-service.
+   *
+   * They can of course be set in Firestore as well, but since firestore is
+   * consumed by all app versions it is cleaner to consume a versioned API
+   * for these breaking / deprecating changes.
+   *
+   */
+  userProfiles: z.array(
+    z.object({
+      userProfileRef: z.string(),
+      maxCount: optionalNullish(z.number()),
+    }),
+  ),
+  maxCountPerOrder: optionalNullish(z.number()),
 });
 
 export const PreassignedFareProduct = z.object({

--- a/src/reference-data.ts
+++ b/src/reference-data.ts
@@ -9,15 +9,27 @@ import {ZoneSelectionMode} from './fare-product-type';
 import {optionalNullish} from './utils/nullish';
 import {TransportModeType, TransportSubmodeType} from './common';
 
-export const Limitations = AppVersionedItemSchema.extend({
+/**
+ * These are only relevant for products, i.e. not supplement products
+ */
+export const PreassignedFareProductLimitations = AppVersionedItemSchema.extend({
+  /**
+   * @deprecated use userProfiles instead
+   */
   userProfileRefs: z.array(z.string()),
+  userProfiles: z.array(
+    z.object({
+      userProfileRef: z.string(),
+      maxCount: z.number(),
+    }),
+  ),
   fareZoneRefs: optionalNullish(z.array(z.string())),
-
   /**
    * @deprecated use fareZoneRefs instead
    */
   tariffZoneRefs: optionalNullish(z.array(z.string())),
   supplementProductRefs: optionalNullish(z.array(z.string())),
+  limitPerOrder: optionalNullish(z.number()),
 });
 
 export const PreassignedFareProduct = z.object({
@@ -26,7 +38,7 @@ export const PreassignedFareProduct = z.object({
   type: z.string(),
   distributionChannel: z.array(z.string()),
   name: LanguageAndTextType,
-  limitations: Limitations,
+  limitations: PreassignedFareProductLimitations,
   durationDays: optionalNullish(z.number()),
   isApplicableOnSingleZoneOnly: optionalNullish(z.boolean()),
   isBookingEnabled: optionalNullish(z.boolean()),
@@ -42,24 +54,24 @@ export const PreassignedFareProduct = z.object({
   warningMessage: optionalNullish(LanguageAndTextTypeArray),
 });
 
-const BaseProduct = z.object({
+const BaseSupplementProduct = z.object({
   id: z.string(),
   version: z.string(),
   distributionChannel: z.array(z.string()),
   name: LanguageAndTextType,
   alternativeNames: optionalNullish(LanguageAndTextTypeArray),
   description: optionalNullish(LanguageAndTextTypeArray),
-  limitations: optionalNullish(Limitations),
+  limitations: optionalNullish(AppVersionedItemSchema),
 });
 
 export const BaggageType = z.enum(['BICYCLE']);
-export const BaggageProduct = BaseProduct.extend({
+export const BaggageProduct = BaseSupplementProduct.extend({
   kind: z.literal('baggage'),
   baggageType: BaggageType,
   illustration: optionalNullish(z.string()),
 });
 
-export const ReservationProduct = BaseProduct.extend({
+export const ReservationProduct = BaseSupplementProduct.extend({
   kind: z.literal('reservation'),
   transportMode: optionalNullish(TransportModeType),
   transportSubmodes: optionalNullish(z.array(TransportSubmodeType)),

--- a/src/tests/fixtures/referenceData.json
+++ b/src/tests/fixtures/referenceData.json
@@ -10,7 +10,11 @@
         "value": "Enkeltbillett"
       },
       "limitations": {
-        "userProfileRefs": ["ATB:UserProfile:2832569f"]
+        "userProfiles": [
+          {
+            "userProfileRef": "ATB:UserProfile:2832569f"
+          }
+        ]
       }
     }
   ],
@@ -31,10 +35,7 @@
         }
       ],
       "kind": "baggage",
-      "baggageType": "BICYCLE",
-      "limitations": {
-        "userProfileRefs": []
-      }
+      "baggageType": "BICYCLE"
     },
     {
       "id": "ATB:SupplementProduct:87654321",
@@ -52,10 +53,7 @@
       ],
       "kind": "reservation",
       "transportMode": "water",
-      "transportSubmodes": ["highSpeedPassengerService"],
-      "limitations": {
-        "userProfileRefs": []
-      }
+      "transportSubmodes": ["highSpeedPassengerService"]
     }
   ],
   "tariffZones": [


### PR DESCRIPTION
Related to https://github.com/AtB-AS/kundevendt/issues/22893

This PR does two things: 
1. **Refactor Limitations**. Previously we had one `Limitations`-type, that was used for both Product-limitations and SupplementProduct limitations. But SupplementProducts do not need `fareZoneRefs`, `supplementProductRefs` or `userProfileRefs` (even if they are currently set for the reservation supplement products. It is never used, and will be removed when this PR is merged) because a supplement product is always linked to a product, and then implicitly has that limitation thorough its associated product. Therefore, rename `Limitations` to `PreassignedFareProductLimitations` to make it clear that they only apply to products and not supplement product, and use `AppVersionedItemSchema` for supplement product limitations, which is the only thing they need. 
2. **Prevent abuse** as mentioned in the issue, so we need to limit how many user profiles can be purchased at a time for different products. There is both a limit on specific userProfiles (so we change from `limitations.userProfileRefs` to `limitations.userProfiles`) and a limit on total user profiles pr. order (so we add a `maxCountPerOrder` to products).

One important detail about point 2 above, is that these new fields are returned from the `product/v2` service only, and are not added to firestore. So we do not have to worry about compatibility with older versions. 