### PR TITLE
refactor: remove bonus source definitions from mobility schema and types

### DIFF
--- a/schema-definitions/mobility.json
+++ b/schema-definitions/mobility.json
@@ -778,56 +778,6 @@
         }
       },
       "required": ["howBonusWorks"]
-    },
-    "bonusSources": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "preassignedFareProductId": {
-            "type": "string"
-          },
-          "userProfileIds": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "fareZones": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "amountByEnrollment": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "enrollmentId": {
-                  "type": "string"
-                },
-                "amount": {
-                  "type": "integer",
-                  "exclusiveMinimum": 0,
-                  "maximum": 9007199254740991
-                }
-              },
-              "required": ["amount"]
-            }
-          }
-        },
-        "required": [
-          "id",
-          "preassignedFareProductId",
-          "userProfileIds",
-          "fareZones",
-          "amountByEnrollment"
-        ]
-      }
     }
   },
   "required": ["operators"]

--- a/src/mobility.ts
+++ b/src/mobility.ts
@@ -1,6 +1,5 @@
 import {z} from 'zod';
 import {LanguageAndTextTypeArray} from './common';
-import {title} from 'process';
 
 export const titleAndDescription = z.object({
   title: LanguageAndTextTypeArray.nonempty(),
@@ -133,18 +132,3 @@ export const BonusTexts = z.object({
 });
 
 export type BonusTextsType = z.infer<typeof BonusTexts>;
-
-export const BonusSource = z.object({
-  id: z.string(),
-  preassignedFareProductId: z.string(),
-  userProfileIds: z.array(z.string()),
-  fareZones: z.array(z.string()),
-  amountByEnrollment: z.array(
-    z.object({
-      enrollmentId: z.string().optional(), // which enrollment (pilot group) a user is in
-      amount: z.number().int().positive(),
-    }),
-  ),
-});
-
-export type BonusSourceType = z.infer<typeof BonusSource>;

--- a/src/tools/specifications-types.ts
+++ b/src/tools/specifications-types.ts
@@ -6,7 +6,6 @@ import {
   BonusTexts,
   MobilityOperator,
   OperatorBenefitId,
-  BonusSource,
   ScooterConsentLine,
   ScooterFaq,
 } from '../mobility';
@@ -65,7 +64,6 @@ export const schemaTypes = {
       benefitIdsRequiringValueCode: z.array(OperatorBenefitId).optional(),
       bonusProducts: z.array(BonusProduct).optional(),
       bonusTexts: BonusTexts.optional(),
-      bonusSources: z.array(BonusSource).optional(),
     })
     .meta({title: 'MobilityOperator'}),
   other: Other,


### PR DESCRIPTION
Remove bonus source definitions from the mobility schema and related types since it will no longer be in use.