### PR TITLE
feat: add KnownQrCodeUrls schema and related types

### DIFF
--- a/schema-definitions/knownQrCodeUrls.json
+++ b/schema-definitions/knownQrCodeUrls.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "KnownQrCodeUrls",
+  "default": {
+    "urls": []
+  },
+  "type": "object",
+  "properties": {
+    "urls": {
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "pattern": {
+            "type": "string",
+            "minLength": 1
+          },
+          "openMode": {
+            "type": "string",
+            "enum": ["in-app-browser", "open-url"]
+          }
+        },
+        "required": ["id", "pattern", "openMode"]
+      }
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,4 @@ export * from './payment-types';
 export * from './other';
 export * from './reference-data';
 export * from './stop-signal-button-config';
+export * from './known-qr-code-urls';

--- a/src/known-qr-code-urls.ts
+++ b/src/known-qr-code-urls.ts
@@ -1,0 +1,19 @@
+import {z} from 'zod';
+
+export const KnownQrCodeUrlOpenMode = z.enum(['in-app-browser', 'open-url']);
+
+export const KnownQrCodeUrl = z.object({
+  id: z.string(),
+  pattern: z.string().min(1),
+  openMode: KnownQrCodeUrlOpenMode,
+});
+
+export const KnownQrCodeUrls = z
+  .object({
+    urls: z.array(KnownQrCodeUrl).default([]),
+  })
+  .default({urls: []});
+
+export type KnownQrCodeUrlType = z.infer<typeof KnownQrCodeUrl>;
+export type KnownQrCodeUrlsType = z.infer<typeof KnownQrCodeUrls>;
+export type KnownQrCodeUrlOpenModeType = z.infer<typeof KnownQrCodeUrlOpenMode>;

--- a/src/tools/specifications-types.ts
+++ b/src/tools/specifications-types.ts
@@ -21,6 +21,7 @@ import {PaymentTypes} from '../payment-types';
 import {Other} from '../other';
 import {ReferenceData} from '../reference-data';
 import {StopSignalButtonConfig} from '../stop-signal-button-config';
+import {KnownQrCodeUrls} from '../known-qr-code-urls';
 import {AppVersionedItem, AppVersionedItemSchema} from '../common';
 
 // All supported specifications
@@ -36,6 +37,7 @@ export const specifications = [
   'consents',
   'referenceData',
   'stopSignalButtonConfig',
+  'knownQrCodeUrls',
 ] as const;
 
 export type SchemaNames = (typeof specifications)[number];
@@ -74,6 +76,7 @@ export const schemaTypes = {
   consents: Consents,
   referenceData: ReferenceData,
   stopSignalButtonConfig: StopSignalButtonConfig,
+  knownQrCodeUrls: KnownQrCodeUrls.meta({title: 'KnownQrCodeUrls'}),
 } satisfies Record<SchemaNames, unknown>;
 
 // All correctly supported schema types as JSON Schema data structures


### PR DESCRIPTION
Introduce a new schema for KnownQrCodeUrls, including validation types and integration into the existing schema types.

resolves https://github.com/AtB-AS/kundevendt/issues/23738