### PR TITLE
fix: remove root default for knownQrCodeUrls

### DIFF
--- a/schema-definitions/knownQrCodeUrls.json
+++ b/schema-definitions/knownQrCodeUrls.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "KnownQrCodeUrls",
-  "default": {
-    "urls": []
-  },
   "type": "object",
   "properties": {
     "urls": {

--- a/src/known-qr-code-urls.ts
+++ b/src/known-qr-code-urls.ts
@@ -8,11 +8,9 @@ export const KnownQrCodeUrl = z.object({
   openMode: KnownQrCodeUrlOpenMode,
 });
 
-export const KnownQrCodeUrls = z
-  .object({
-    urls: z.array(KnownQrCodeUrl).default([]),
-  })
-  .default({urls: []});
+export const KnownQrCodeUrls = z.object({
+  urls: z.array(KnownQrCodeUrl).default([]),
+});
 
 export type KnownQrCodeUrlType = z.infer<typeof KnownQrCodeUrl>;
 export type KnownQrCodeUrlsType = z.infer<typeof KnownQrCodeUrls>;


### PR DESCRIPTION
Remove the default value for the root object in the KnownQrCodeUrls schema.

resolves https://github.com/AtB-AS/kundevendt/issues/23738