### PR TITLE
feat!: select shmo bonus products and price adjustments by vehicleTypeId

### DIFF
--- a/schema-definitions/mobility.json
+++ b/schema-definitions/mobility.json
@@ -295,55 +295,6 @@
               ]
             }
           },
-          "priceAdjustments": {
-            "type": "object",
-            "propertyNames": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "const": "SCOOTER"
-                },
-                {
-                  "type": "string",
-                  "const": "SCOOTER_STANDING"
-                },
-                {
-                  "type": "string",
-                  "const": "BICYCLE"
-                },
-                {
-                  "type": "string",
-                  "const": "CAR"
-                }
-              ]
-            },
-            "additionalProperties": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "amount": {
-                    "type": "number"
-                  },
-                  "description": {
-                    "type": "string"
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": ["FREE_UNLOCK", "FREE_MINUTES"]
-                  },
-                  "systemIds": {
-                    "default": [],
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "required": ["amount", "description", "type"]
-              }
-            }
-          },
           "brandAssets": {
             "description": "modeled 1-1 like brandAssets in EnTur mobility API",
             "type": "object",
@@ -602,28 +553,11 @@
             "type": "string",
             "minLength": 1
           },
-          "formFactors": {
+          "vehicleTypeIds": {
             "minItems": 1,
             "type": "array",
             "items": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "const": "SCOOTER"
-                },
-                {
-                  "type": "string",
-                  "const": "SCOOTER_STANDING"
-                },
-                {
-                  "type": "string",
-                  "const": "BICYCLE"
-                },
-                {
-                  "type": "string",
-                  "const": "CAR"
-                }
-              ]
+              "type": "string"
             }
           },
           "price": {
@@ -745,7 +679,7 @@
           "id",
           "isActive",
           "operatorId",
-          "formFactors",
+          "vehicleTypeIds",
           "price",
           "paymentDescription",
           "productDescription"
@@ -825,6 +759,38 @@
         }
       },
       "required": ["howBonusWorks"]
+    },
+    "priceAdjustments": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "amount": {
+              "type": "number"
+            },
+            "description": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": ["FREE_UNLOCK", "FREE_MINUTES"]
+            },
+            "systemIds": {
+              "default": [],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": ["amount", "description", "type"]
+        }
+      }
     }
   },
   "required": ["operators"]

--- a/src/mobility.ts
+++ b/src/mobility.ts
@@ -57,13 +57,13 @@ export const PriceAdjustment = z.object({
 
 export type PriceAdjustmentType = z.infer<typeof PriceAdjustment>;
 
-export const PriceAdjustmentsByFormFactor = z.partialRecord(
-  FormFactor,
+export const PriceAdjustmentsByVehicleTypeId = z.record(
+  z.string(),
   z.array(PriceAdjustment),
 );
 
-export type PriceAdjustmentsByFormFactorType = Partial<
-  Record<FormFactorType, PriceAdjustmentType[]>
+export type PriceAdjustmentsByVehicleTypeIdType = z.infer<
+  typeof PriceAdjustmentsByVehicleTypeId
 >;
 
 export const MobilityOperator = z.object({
@@ -72,7 +72,6 @@ export const MobilityOperator = z.object({
   showInApp: z.boolean().default(false),
   formFactors: z.array(FormFactor).nonempty(),
   benefits: z.array(OperatorBenefit).optional().default([]),
-  priceAdjustments: PriceAdjustmentsByFormFactor.optional(),
   brandAssets: z
     .object({
       brandLastModified: z.string().date(),
@@ -116,7 +115,7 @@ export const BonusProduct = z.object({
   id: z.string().nonempty(),
   isActive: z.boolean(),
   operatorId: MobilityOperator.shape.id,
-  formFactors: z.array(FormFactor).nonempty(),
+  vehicleTypeIds: z.array(z.string()).nonempty(),
   price: z.object({
     amount: z.number().int().positive(),
     currencyCode: z.literal('ATB_BONUS_POINT'),

--- a/src/tools/specifications-types.ts
+++ b/src/tools/specifications-types.ts
@@ -7,6 +7,7 @@ import {
   ConsentLine,
   MobilityOperator,
   OperatorBenefitId,
+  PriceAdjustmentsByVehicleTypeId,
   ScooterFaq,
 } from '../mobility';
 import {
@@ -65,6 +66,7 @@ export const schemaTypes = {
       benefitIdsRequiringValueCode: z.array(OperatorBenefitId).optional(),
       bonusProducts: z.array(BonusProduct).optional(),
       bonusTexts: BonusTexts.optional(),
+      priceAdjustments: PriceAdjustmentsByVehicleTypeId.optional(),
     })
     .meta({title: 'MobilityOperator'}),
   other: Other,


### PR DESCRIPTION
Resolves AtB-AS/kundevendt#23889

## Summary

Full change overview: https://htmlpreview.github.io/?https://gist.githubusercontent.com/adriansberg/c2b51ea01ae21f4da079342b8ef493bd/raw/explanation.html

Breaking schema change: switch shared-mobility bonus product matching and price adjustment lookup from `operatorId + formFactor` to `vehicleTypeId`.

## Changes

- `BonusProduct`: replace `formFactors: z.array(FormFactor).nonempty()` with `vehicleTypeIds: z.array(z.string()).nonempty()`. `operatorId` kept — still needed for voucher products.
- `MobilityOperator`: remove `priceAdjustments` (was keyed by `FormFactor`)
- Remove `PriceAdjustmentsByFormFactor` type (no longer used)
- `specifications-types.ts`: add top-level `priceAdjustments: PriceAdjustmentsByVehicleTypeId` to mobility object — a single map keyed by `vehicleTypeId`
- Add `PriceAdjustmentsByVehicleTypeId` type: `z.record(z.string(), z.array(PriceAdjustment))`
- Regenerated `schema-definitions/mobility.json`

## Breaking change

Consumers must migrate from `operator.priceAdjustments[formFactor]` to top-level `priceAdjustments[vehicleTypeId]`, and from `bonusProduct.formFactors` to `bonusProduct.vehicleTypeIds`.

## Test plan

- [ ] `yarn build` passes (regenerates mobility.json)
- [ ] `yarn test` passes
- [ ] `vehicleTypeIds` required on `BonusProduct` in generated schema
- [ ] Top-level `priceAdjustments` present in generated schema