### PR TITLE
feat: fareZoneSummaryStyle

### DIFF
--- a/schema-definitions/referenceData.json
+++ b/schema-definitions/referenceData.json
@@ -144,7 +144,7 @@
             "anyOf": [
               {
                 "type": "string",
-                "const": "none"
+                "enum": ["none"]
               },
               {
                 "type": "null"

--- a/schema-definitions/referenceData.json
+++ b/schema-definitions/referenceData.json
@@ -140,6 +140,17 @@
               }
             ]
           },
+          "fareZoneSummaryStyle": {
+            "anyOf": [
+              {
+                "type": "string",
+                "const": "none"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "isBookingEnabled": {
             "anyOf": [
               {

--- a/src/reference-data.ts
+++ b/src/reference-data.ts
@@ -20,6 +20,8 @@ export const Limitations = AppVersionedItemSchema.extend({
   supplementProductRefs: optionalNullish(z.array(z.string())),
 });
 
+export const FareZoneSummaryStyle = z.enum(['none']);
+
 export const PreassignedFareProduct = z.object({
   id: z.string(),
   version: z.string(),
@@ -29,6 +31,7 @@ export const PreassignedFareProduct = z.object({
   limitations: Limitations,
   durationDays: optionalNullish(z.number()),
   isApplicableOnSingleZoneOnly: optionalNullish(z.boolean()),
+  fareZoneSummaryStyle: optionalNullish(FareZoneSummaryStyle),
   isBookingEnabled: optionalNullish(z.boolean()),
   isEnabledForTripSearchOffer: optionalNullish(z.boolean()),
   isDefault: optionalNullish(z.boolean()),


### PR DESCRIPTION
Configuration needed to solve https://github.com/AtB-AS/kundevendt/issues/24086. 

For products with `fareZoneSummaryStyle: 'none'` we hide the zone-summary for a bought ticket. This is needed by VKT because they don't want to list all zones in their travel rights. 